### PR TITLE
feat: add accessible mosaic ui framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,113 @@
-# mosaic
+# Mosaic UI
+
+Mosaic is an ergonomic React component framework built for inclusive, themeable interfaces. It ships with an opinionated theming system, accessibility-first primitives, and helpers for color vision, high-contrast, and reduced-motion experiences — all powered by Bun.
+
+## Features
+
+- **Adaptive theming** – Toggle light/dark appearance, swap accent palettes, and generate CSS variables for any surface.
+- **Color vision awareness** – Built-in palettes for protanopia, deuteranopia, tritanopia, and achromatopsia modes maintain contrast and readability.
+- **High contrast & reduced motion** – Global switches alter tokens, shadows, and motion variables so interactions remain comfortable for every user.
+- **Composable primitives** – Buttons, cards, text, inputs, layout utilities, and form helpers share a unified design language.
+- **Developer ergonomics** – A single `ThemeProvider`, ergonomic hooks, and a drop-in `ThemePanel` make experimentation fast.
+
+## Installation
+
+```bash
+bun install mosaic-ui
+```
+
+During development you can link the package locally:
+
+```bash
+bun install
+bun run build
+```
+
+The build script emits both ESM bundles and TypeScript declarations in `dist/`.
+
+## Usage
+
+Wrap your application with the `ThemeProvider`. Mosaic automatically syncs with system preferences and exposes helpers via `useTheme`.
+
+```tsx
+import { ThemeProvider, Stack, Card, Button, Text, ThemePanel } from "mosaic-ui";
+
+export function App() {
+  return (
+    <ThemeProvider>
+      <Stack gap="lg" style={{ padding: "2rem" }}>
+        <Card tone="primary" hoverable>
+          <Stack gap="sm">
+            <Text variant="headline">Welcome to Mosaic</Text>
+            <Text>
+              Use the controls below to explore color palettes, accessibility modes, and motion preferences.
+            </Text>
+            <Button onClick={() => console.log("hello")}>
+              Get started
+            </Button>
+          </Stack>
+        </Card>
+        <ThemePanel />
+      </Stack>
+    </ThemeProvider>
+  );
+}
+```
+
+### Accessing theme tokens
+
+`useTheme` returns the active theme and ergonomic setters:
+
+```tsx
+import { useTheme } from "mosaic-ui";
+
+const { appearance, toggleAppearance, highContrast, toggleHighContrast } = useTheme();
+```
+
+Use `getCssVar("color-primary")` inside component styles to reference tokens, or grab `cssVariables` for inline styles.
+
+### Components
+
+- `Button` – Solid, soft, outline, and ghost variants with tone-aware styling and loading states.
+- `Card` – Themed surfaces with padding controls, elevation, and hover affordances.
+- `Text` – Semantic typography variants with tone helpers and truncation support.
+- `Stack` – Flexbox layout utility for column/row alignment and spacing.
+- `Input` – Accessible text input with size and validation states.
+- `Field` – Form wrapper that wires labels, hints, and errors to controls automatically.
+- `ThemePanel` – Drop-in accessibility toolbar for rapid prototyping.
+- `VisuallyHidden` – A utility for screen-reader only content.
+
+## Theming API
+
+`ThemeProvider` accepts optional configuration:
+
+```tsx
+<ThemeProvider
+  initialTheme={{ appearance: "dark", accent: "emerald" }}
+  storageKey="mosaic-theme"
+>
+  {children}
+</ThemeProvider>
+```
+
+Options include:
+
+- `appearance`: `"light" | "dark"`
+- `accent`: palette token (`"indigo"`, `"azure"`, `"violet"`, `"emerald"`, `"amber"`, `"rose"`, or `"neutral"`)
+- `colorVision`: color-vision mode (`"normal"`, `"protanopia"`, `"deuteranopia"`, `"tritanopia"`, `"achromatopsia"`)
+- `highContrast`: boolean for contrast-first visuals
+- `reducedMotion`: boolean to shorten or remove transitions
+
+When `storageKey` is provided, preferences persist to `localStorage`. Setting `syncWithSystem={false}` disables automatic media-query syncing.
+
+## Scripts
+
+| Command              | Description                          |
+| -------------------- | ------------------------------------ |
+| `bun run build`      | Emit `.d.ts` files and ESM bundle.   |
+| `bun run typecheck`  | Type-check the source code.          |
+| `bun test`           | Reserved for future unit tests.      |
+
+## License
+
+MIT © 2024 Mosaic Contributors

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Mosaic is an ergonomic React component framework built for inclusive, themeable 
 - **Adaptive theming** – Toggle light/dark appearance, swap accent palettes, and generate CSS variables for any surface.
 - **Color vision awareness** – Built-in palettes for protanopia, deuteranopia, tritanopia, and achromatopsia modes maintain contrast and readability.
 - **High contrast & reduced motion** – Global switches alter tokens, shadows, and motion variables so interactions remain comfortable for every user.
+- **Keyboard-first navigation** – Global shortcuts, a modal command palette (`⌘/Ctrl + K`), tooltip hints, and context menus all share the same registry.
 - **Composable primitives** – Buttons, cards, text, inputs, layout utilities, and form helpers share a unified design language.
 - **Developer ergonomics** – A single `ThemeProvider`, ergonomic hooks, and a drop-in `ThemePanel` make experimentation fast.
+- **Kitchen-sink playground** – Run `bun dev` to explore every primitive with live tokens, accessibility toggles, and keyboard shortcuts.
 
 ## Installation
 
@@ -27,30 +29,70 @@ The build script emits both ESM bundles and TypeScript declarations in `dist/`.
 
 ## Usage
 
-Wrap your application with the `ThemeProvider`. Mosaic automatically syncs with system preferences and exposes helpers via `useTheme`.
+Wrap your application with the `ThemeProvider`, `ShortcutsProvider`, `ToastProvider`, and `CommandPalette` to wire theming, keyboard shortcuts, and notifications. Mosaic automatically syncs with system preferences and exposes helpers via `useTheme`.
 
 ```tsx
-import { ThemeProvider, Stack, Card, Button, Text, ThemePanel } from "mosaic-ui";
+import {
+  Button,
+  Card,
+  CommandPalette,
+  ShortcutsProvider,
+  Stack,
+  Text,
+  ThemePanel,
+  ThemeProvider,
+  ToastProvider,
+} from "mosaic-ui";
 
 export function App() {
   return (
     <ThemeProvider>
-      <Stack gap="lg" style={{ padding: "2rem" }}>
-        <Card tone="primary" hoverable>
-          <Stack gap="sm">
-            <Text variant="headline">Welcome to Mosaic</Text>
-            <Text>
-              Use the controls below to explore color palettes, accessibility modes, and motion preferences.
-            </Text>
-            <Button onClick={() => console.log("hello")}>
-              Get started
-            </Button>
-          </Stack>
-        </Card>
-        <ThemePanel />
-      </Stack>
+      <ShortcutsProvider>
+        <ToastProvider>
+          <CommandPalette>
+            <Stack gap="lg" style={{ padding: "2rem" }}>
+              <Card tone="primary" hoverable>
+                <Stack gap="sm">
+                  <Text variant="headline">Welcome to Mosaic</Text>
+                  <Text>
+                    Use the controls below to explore palettes, accessibility modes, keyboard shortcuts, and motion preferences.
+                  </Text>
+                  <Button onClick={() => console.log("hello")}>Open palette (⌘/Ctrl + K)</Button>
+                </Stack>
+              </Card>
+              <ThemePanel />
+            </Stack>
+          </CommandPalette>
+        </ToastProvider>
+      </ShortcutsProvider>
     </ThemeProvider>
   );
+}
+```
+
+### Registering keyboard commands
+
+`useCommand` ties actions to the shortcut registry and command palette:
+
+```tsx
+import { Button, useCommand, useCommandPalette, useToast } from "mosaic-ui";
+
+function KeyboardDemo() {
+  const { toggle } = useCommandPalette();
+  const { toast } = useToast();
+
+  useCommand(
+    {
+      id: "demo.toast",
+      title: "Trigger success toast",
+      combo: "mod+shift+t",
+      run: () => toast({ title: "Notified!", tone: "success" }),
+      keywords: ["toast", "notification"],
+    },
+    [toast],
+  );
+
+  return <Button onClick={toggle}>Open command palette</Button>;
 }
 ```
 
@@ -68,13 +110,27 @@ Use `getCssVar("color-primary")` inside component styles to reference tokens, or
 
 ### Components
 
-- `Button` – Solid, soft, outline, and ghost variants with tone-aware styling and loading states.
+- `Avatar` – Adaptive initials and imagery with sizing and fallback states.
+- `Badge` – Tone-aware indicators with solid, soft, and outline variants.
+- `Button` – Solid, soft, outline, ghost, and loading states with tone tokens.
 - `Card` – Themed surfaces with padding controls, elevation, and hover affordances.
-- `Text` – Semantic typography variants with tone helpers and truncation support.
-- `Stack` – Flexbox layout utility for column/row alignment and spacing.
-- `Input` – Accessible text input with size and validation states.
+- `Checkbox` – Supports indeterminate and descriptive labels out of the box.
+- `Combobox` – Searchable option list with keyboard support and optional clearing.
+- `CommandPalette` – Global spotlight surfaced via `⌘/Ctrl + K`, powered by shared shortcuts.
+- `ContextMenu` – Accessible right-click menus with shortcut hints and keyboard navigation.
+- `DataTable` – Sortable tabular data with alignment controls and empty states.
+- `DatePicker` – Styled native date input that adopts Mosaic tokens.
+- `Dialog` & `Sheet` – Modal and slide-over overlays with focus traps and motion awareness.
 - `Field` – Form wrapper that wires labels, hints, and errors to controls automatically.
+- `Input` – Accessible text input with size and validation states.
+- `Pagination` – Paginated navigation with ellipsis handling.
+- `Progress` – Determinate and indeterminate indicators with optional labels.
+- `Stack` – Flexbox layout utility for column/row alignment and spacing.
+- `Switch` – Accessible toggle with descriptive text support.
+- `Text` – Semantic typography variants with tone helpers and truncation support.
 - `ThemePanel` – Drop-in accessibility toolbar for rapid prototyping.
+- `Tooltip` – Directional hover/focus hints with shortcut callouts.
+- `ToastProvider` / `useToast` – Toast notifications with tone variants and actions.
 - `VisuallyHidden` – A utility for screen-reader only content.
 
 ## Theming API
@@ -99,6 +155,16 @@ Options include:
 - `reducedMotion`: boolean to shorten or remove transitions
 
 When `storageKey` is provided, preferences persist to `localStorage`. Setting `syncWithSystem={false}` disables automatic media-query syncing.
+
+## Documentation playground
+
+Explore every primitive, shortcut, and accessibility toggle by running the kitchen-sink demo:
+
+```bash
+bun dev
+```
+
+Vite serves the site on [http://localhost:5173](http://localhost:5173) with hot reloading.
 
 ## Scripts
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,26 +5,238 @@
       "name": "mosaic-ui",
       "dependencies": {
         "react": "^18.3.1",
+        "react-dom": "^18.3.1",
       },
       "devDependencies": {
         "@types/react": "^18.3.4",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.2",
         "typescript": "^5.6.3",
+        "vite": "^5.4.8",
       },
     },
   },
   "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.28.4", "", {}, "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw=="],
+
+    "@babel/core": ["@babel/core@7.28.4", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.3", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-module-transforms": "^7.28.3", "@babel/helpers": "^7.28.4", "@babel/parser": "^7.28.4", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.4", "@babel/types": "^7.28.4", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA=="],
+
+    "@babel/generator": ["@babel/generator@7.28.3", "", { "dependencies": { "@babel/parser": "^7.28.3", "@babel/types": "^7.28.2", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.27.2", "", { "dependencies": { "@babel/compat-data": "^7.27.2", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.3", "", { "dependencies": { "@babel/helper-module-imports": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1", "@babel/traverse": "^7.28.3" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.27.1", "", {}, "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.28.4", "", { "dependencies": { "@babel/template": "^7.27.2", "@babel/types": "^7.28.4" } }, "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w=="],
+
+    "@babel/parser": ["@babel/parser@7.28.4", "", { "dependencies": { "@babel/types": "^7.28.4" }, "bin": "./bin/babel-parser.js" }, "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
+
+    "@babel/traverse": ["@babel/traverse@7.28.4", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.3", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.4", "@babel/template": "^7.27.2", "@babel/types": "^7.28.4", "debug": "^4.3.1" } }, "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ=="],
+
+    "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.52.0", "", { "os": "android", "cpu": "arm" }, "sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.52.0", "", { "os": "android", "cpu": "arm64" }, "sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.52.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.52.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.52.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.52.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.52.0", "", { "os": "linux", "cpu": "arm" }, "sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.52.0", "", { "os": "linux", "cpu": "arm" }, "sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.52.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.52.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.52.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.52.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.52.0", "", { "os": "linux", "cpu": "x64" }, "sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.52.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.52.0", "", { "os": "none", "cpu": "arm64" }, "sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.52.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.52.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.52.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.52.0", "", { "os": "win32", "cpu": "x64" }, "sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
     "@types/react": ["@types/react@18.3.24", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.0.2" } }, "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A=="],
 
+    "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.8.6", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw=="],
+
+    "browserslist": ["browserslist@4.26.2", "", { "dependencies": { "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001741", "electron-to-chromium": "^1.5.218", "node-releases": "^2.0.21", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001743", "", {}, "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.222", "", {}, "sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w=="],
+
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "node-releases": ["node-releases@2.0.21", "", {}, "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "rollup": ["rollup@4.52.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.0", "@rollup/rollup-android-arm64": "4.52.0", "@rollup/rollup-darwin-arm64": "4.52.0", "@rollup/rollup-darwin-x64": "4.52.0", "@rollup/rollup-freebsd-arm64": "4.52.0", "@rollup/rollup-freebsd-x64": "4.52.0", "@rollup/rollup-linux-arm-gnueabihf": "4.52.0", "@rollup/rollup-linux-arm-musleabihf": "4.52.0", "@rollup/rollup-linux-arm64-gnu": "4.52.0", "@rollup/rollup-linux-arm64-musl": "4.52.0", "@rollup/rollup-linux-loong64-gnu": "4.52.0", "@rollup/rollup-linux-ppc64-gnu": "4.52.0", "@rollup/rollup-linux-riscv64-gnu": "4.52.0", "@rollup/rollup-linux-riscv64-musl": "4.52.0", "@rollup/rollup-linux-s390x-gnu": "4.52.0", "@rollup/rollup-linux-x64-gnu": "4.52.0", "@rollup/rollup-linux-x64-musl": "4.52.0", "@rollup/rollup-openharmony-arm64": "4.52.0", "@rollup/rollup-win32-arm64-msvc": "4.52.0", "@rollup/rollup-win32-ia32-msvc": "4.52.0", "@rollup/rollup-win32-x64-gnu": "4.52.0", "@rollup/rollup-win32-x64-msvc": "4.52.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g=="],
+
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
+
+    "vite": ["vite@5.4.20", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,30 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "mosaic-ui",
+      "dependencies": {
+        "react": "^18.3.1",
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.4",
+        "typescript": "^5.6.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
+
+    "@types/react": ["@types/react@18.3.24", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.0.2" } }, "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A=="],
+
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+  }
+}

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,1 @@
+jsx = "react-jsx"

--- a/docs/App.tsx
+++ b/docs/App.tsx
@@ -1,0 +1,404 @@
+import { useMemo, useRef, useState } from "react";
+import {
+  Avatar,
+  Badge,
+  Button,
+  Card,
+  Checkbox,
+  Combobox,
+  ContextMenu,
+  DataTable,
+  DatePicker,
+  Dialog,
+  Field,
+  Input,
+  Pagination,
+  Progress,
+  Sheet,
+  Stack,
+  Switch,
+  Text,
+  ThemePanel,
+  Tooltip,
+  useCommand,
+  useCommandPalette,
+  useTheme,
+  useToast,
+} from "@mosaic";
+import type { DataTableColumn } from "@mosaic/components/DataTable";
+
+interface Customer {
+  id: string;
+  company: string;
+  status: "Active" | "Invited" | "Trial" | "Disabled";
+  plan: string;
+  seats: number;
+  lastActive: string;
+}
+
+const customers: Customer[] = [
+  { id: "acme", company: "Acme Inc.", status: "Active", plan: "Enterprise", seats: 12, lastActive: "2024-10-18" },
+  { id: "lumen", company: "Lumen Systems", status: "Trial", plan: "Pro", seats: 5, lastActive: "2024-10-16" },
+  { id: "nova", company: "Nova Analytics", status: "Invited", plan: "Starter", seats: 3, lastActive: "2024-10-11" },
+  { id: "apex", company: "Apex Studios", status: "Active", plan: "Pro", seats: 7, lastActive: "2024-10-20" },
+  { id: "orbital", company: "Orbital Labs", status: "Disabled", plan: "Enterprise", seats: 18, lastActive: "2024-09-24" },
+];
+
+const customerColumns: DataTableColumn<Customer>[] = [
+  {
+    key: "company",
+    header: "Company",
+    accessor: (row) => row.company,
+    sortable: true,
+  },
+  {
+    key: "status",
+    header: "Status",
+    accessor: (row) => (
+      <Badge tone={row.status === "Disabled" ? "danger" : row.status === "Trial" ? "warning" : "success"}>
+        {row.status}
+      </Badge>
+    ),
+    sortAccessor: (row) => row.status,
+    sortable: true,
+  },
+  {
+    key: "plan",
+    header: "Plan",
+    accessor: (row) => row.plan,
+    sortable: true,
+  },
+  {
+    key: "seats",
+    header: "Seats",
+    accessor: (row) => row.seats,
+    align: "right",
+    sortable: true,
+  },
+  {
+    key: "lastActive",
+    header: "Last active",
+    accessor: (row) => row.lastActive,
+    sortAccessor: (row) => new Date(row.lastActive),
+    sortable: true,
+  },
+];
+
+const languageOptions = [
+  { value: "react", label: "React", description: "Declarative UI library" },
+  { value: "vue", label: "Vue", description: "Progressive framework" },
+  { value: "svelte", label: "Svelte", description: "Compiled UI toolkit" },
+  { value: "angular", label: "Angular", description: "Batteries included platform" },
+  { value: "solid", label: "Solid", description: "Fine-grained reactivity" },
+];
+
+const copyPageUrl = () => {
+  if (typeof window === "undefined" || typeof navigator === "undefined") return;
+  navigator.clipboard?.writeText(window.location.href).catch(() => {
+    /* noop */
+  });
+};
+
+const contextMenuItems = [
+  { id: "copy", label: "Copy link", shortcut: "mod+c", onSelect: copyPageUrl },
+  { id: "duplicate", label: "Duplicate", shortcut: "mod+d", onSelect: () => console.log("duplicate") },
+  { separator: true },
+  { id: "archive", label: "Archive", shortcut: "shift+a", onSelect: () => console.log("archive") },
+];
+
+const Hero = ({ onOpenPalette }: { onOpenPalette: () => void }) => (
+  <Card tone="primary" hoverable>
+    <Stack gap="md">
+      <Stack gap="sm">
+        <Text variant="headline">Mosaic UI kitchen sink</Text>
+        <Text variant="body">
+          Explore accessible primitives, keyboard shortcuts, and adaptive theming. Press <Badge tone="neutral">⌘ K</Badge> or use the
+          buttons below to try the command palette.
+        </Text>
+      </Stack>
+      <Stack direction="row" gap="sm" wrap>
+        <Button onClick={onOpenPalette}>Open palette</Button>
+        <Tooltip label="Show a success toast" shortcut="mod+shift+t">
+          <Button variant="outline" tone="success" id="toast-trigger">
+            Trigger toast
+          </Button>
+        </Tooltip>
+      </Stack>
+    </Stack>
+  </Card>
+);
+
+const App = () => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [activePage, setActivePage] = useState(1);
+  const [framework, setFramework] = useState<string | null>(languageOptions[0]?.value ?? null);
+  const [progress, setProgress] = useState(45);
+  const themePanelRef = useRef<HTMLDivElement | null>(null);
+  const { toast } = useToast();
+  const { togglePalette } = useCommandPalette();
+  const { toggleAppearance } = useTheme();
+
+  const visibleCustomers = useMemo(() => customers.slice((activePage - 1) * 2, (activePage - 1) * 2 + 2), [activePage]);
+  const pageCount = Math.max(1, Math.ceil(customers.length / 2));
+
+  const showToast = (tone: "primary" | "success" | "warning" | "danger") => {
+    const toneTitles = {
+      primary: "Heads up",
+      success: "Success",
+      warning: "Careful",
+      danger: "Action required",
+    } as const;
+    toast({
+      title: toneTitles[tone],
+      description: "You can trigger this from the command palette, too.",
+      tone,
+    });
+  };
+
+  useCommand(
+    {
+      id: "demo.open-dialog",
+      title: "Open invite dialog",
+      combo: "mod+shift+d",
+      run: () => setDialogOpen(true),
+      keywords: ["modal", "dialog", "invite"],
+    },
+    [setDialogOpen],
+  );
+
+  useCommand(
+    {
+      id: "demo.open-sheet",
+      title: "Open quick settings sheet",
+      combo: "mod+shift+s",
+      run: () => setSheetOpen(true),
+      keywords: ["sheet", "settings"],
+    },
+    [setSheetOpen],
+  );
+
+  useCommand(
+    {
+      id: "demo.show-toast",
+      title: "Show success toast",
+      combo: "mod+shift+t",
+      run: () => showToast("success"),
+      keywords: ["toast", "notification"],
+    },
+    [toast],
+  );
+
+  useCommand(
+    {
+      id: "demo.toggle-theme",
+      title: "Toggle appearance",
+      combo: "mod+shift+l",
+      run: () => toggleAppearance(),
+      keywords: ["theme", "appearance"],
+    },
+    [toggleAppearance],
+  );
+
+  useCommand(
+    {
+      id: "demo.focus-theme",
+      title: "Scroll to theme settings",
+      description: "Jump to accessibility controls",
+      run: () => themePanelRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }),
+      keywords: ["theme", "settings"],
+    },
+    [],
+  );
+
+  return (
+    <div className="app">
+      <main className="app-main">
+        <Hero onOpenPalette={togglePalette} />
+
+        <section>
+          <Text variant="title">Inputs & controls</Text>
+          <Card>
+            <Stack gap="md">
+              <Stack direction="row" gap="md" wrap>
+                <Field label="Name">
+                  <Input placeholder="Jane Doe" autoComplete="off" />
+                </Field>
+                <Field label="Project start">
+                  <DatePicker />
+                </Field>
+              </Stack>
+              <Stack direction="row" gap="md" wrap>
+                <Switch>Share updates automatically</Switch>
+                <Checkbox description="Invite this teammate to beta features" defaultChecked>
+                  Early access
+                </Checkbox>
+                <Badge tone="primary">Beta</Badge>
+                <Badge tone="neutral" variant="outline">
+                  Outline
+                </Badge>
+              </Stack>
+              <Stack direction="row" gap="md" wrap align="center">
+                <Combobox
+                  options={languageOptions}
+                  value={framework}
+                  onValueChange={setFramework}
+                  placeholder="Search frameworks"
+                  id="frameworks"
+                />
+                <Tooltip label="This action opens a toast" shortcut="mod+shift+t">
+                  <Button onClick={() => showToast("primary")} variant="soft">
+                    Notify team
+                  </Button>
+                </Tooltip>
+                <Button tone="danger" variant="outline" onClick={() => showToast("danger")}>
+                  Delete sample
+                </Button>
+              </Stack>
+            </Stack>
+          </Card>
+        </section>
+
+        <section>
+          <Text variant="title">Avatars & status</Text>
+          <Card>
+            <Stack direction="row" gap="md" align="center">
+              <Avatar name="Samantha Rivers" src="https://i.pravatar.cc/120?img=32" />
+              <Avatar name="Alex Chen" size="lg" fallback="AC" />
+              <Avatar name="Sophie Alvarez" size="sm" />
+            </Stack>
+          </Card>
+        </section>
+
+        <section>
+          <Text variant="title">Tables & data</Text>
+          <Card>
+            <DataTable<Customer>
+              data={visibleCustomers}
+              columns={customerColumns}
+              rowKey={(row) => row.id}
+              caption="Recent customer activity"
+              defaultSort={{ columnKey: "company", direction: "asc" }}
+            />
+            <Stack direction="row" align="center" justify="space-between">
+              <Text variant="caption">Page {activePage} of {pageCount}</Text>
+              <Pagination page={activePage} pageCount={pageCount} onPageChange={setActivePage} />
+            </Stack>
+          </Card>
+        </section>
+
+        <section>
+          <Text variant="title">Progress & feedback</Text>
+          <Card>
+            <Stack gap="sm">
+              <Progress label="Invite campaign" value={progress} showValue />
+              <Stack direction="row" gap="sm">
+                <Button tone="neutral" variant="outline" onClick={() => setProgress((value) => Math.max(0, value - 10))}>
+                  Slow down
+                </Button>
+                <Button tone="primary" onClick={() => setProgress((value) => Math.min(100, value + 10))}>
+                  Speed up
+                </Button>
+              </Stack>
+            </Stack>
+          </Card>
+        </section>
+
+        <section>
+          <Text variant="title">Context menus & toasts</Text>
+          <Stack direction="row" gap="md" wrap>
+            <ContextMenu items={contextMenuItems}>
+              <Card hoverable>
+                <Stack gap="sm">
+                  <Text variant="title">Right-click me</Text>
+                  <Text variant="body">Open the contextual actions menu anywhere in this card.</Text>
+                </Stack>
+              </Card>
+            </ContextMenu>
+            <Card>
+              <Stack gap="sm">
+                <Text variant="title">Notifications</Text>
+                <Stack direction="row" gap="sm" wrap>
+                  <Button tone="success" variant="soft" onClick={() => showToast("success")}>Success</Button>
+                  <Button tone="warning" variant="soft" onClick={() => showToast("warning")}>Warning</Button>
+                  <Button tone="danger" variant="soft" onClick={() => showToast("danger")}>Danger</Button>
+                </Stack>
+              </Stack>
+            </Card>
+          </Stack>
+        </section>
+
+        <section>
+          <Text variant="title">Overlays</Text>
+          <Stack direction="row" gap="sm" wrap>
+            <Button onClick={() => setDialogOpen(true)}>Open dialog</Button>
+            <Button onClick={() => setSheetOpen(true)} variant="outline">
+              Open sheet
+            </Button>
+          </Stack>
+        </section>
+      </main>
+      <aside className="app-sidebar" ref={themePanelRef}>
+        <ThemePanel />
+      </aside>
+
+      <Dialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        title="Invite teammate"
+        description="Send a quick invite and assign a role."
+        footer={
+          <Stack direction="row" gap="sm">
+            <Button variant="ghost" tone="neutral" onClick={() => setDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={() => {
+              showToast("success");
+              setDialogOpen(false);
+            }}>
+              Send invite
+            </Button>
+          </Stack>
+        }
+      >
+        <Stack gap="md">
+          <Field label="Email">
+            <Input type="email" placeholder="name@company.com" />
+          </Field>
+          <Field label="Role">
+            <Combobox
+              options={[
+                { value: "admin", label: "Administrator" },
+                { value: "editor", label: "Editor" },
+                { value: "viewer", label: "Viewer" },
+              ]}
+              defaultValue="editor"
+              onValueChange={() => {}}
+            />
+          </Field>
+          <Checkbox defaultChecked>Email teammates about new features</Checkbox>
+        </Stack>
+      </Dialog>
+
+      <Sheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        title="Quick settings"
+        description="Personalize the preview environment."
+        side="right"
+      >
+        <Stack gap="md">
+          <Switch defaultChecked>Enable onboarding tips</Switch>
+          <Switch>Mute email digests</Switch>
+          <Checkbox>Enable experimental API</Checkbox>
+          <Stack gap="sm">
+            <Text variant="label">System load</Text>
+            <Progress value={72} showValue />
+          </Stack>
+        </Stack>
+      </Sheet>
+    </div>
+  );
+};
+
+export default App;

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mosaic UI Kitchen Sink</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/docs/main.tsx
+++ b/docs/main.tsx
@@ -1,0 +1,31 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+import {
+  CommandPalette,
+  ShortcutsProvider,
+  ThemeProvider,
+  ToastProvider,
+} from "@mosaic";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Failed to find the root element");
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <ThemeProvider storageKey="mosaic-docs-theme">
+      <ShortcutsProvider>
+        <ToastProvider>
+          <CommandPalette>
+            <App />
+          </CommandPalette>
+        </ToastProvider>
+      </ShortcutsProvider>
+    </ThemeProvider>
+  </StrictMode>,
+);

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,70 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--mosaic-font-family-base, "Inter", system-ui, -apple-system, sans-serif);
+  background: var(--mosaic-color-background);
+  color: var(--mosaic-color-text);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  transition: background-color 180ms ease, color 180ms ease;
+}
+
+.app {
+  min-height: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+  gap: clamp(2rem, 5vw, 3rem);
+  padding: clamp(1.5rem, 5vw, 3.5rem);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.app-main section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-md);
+}
+
+.app-sidebar {
+  position: sticky;
+  top: clamp(1.5rem, 4vw, 3rem);
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-lg);
+}
+
+.app-sidebar > * {
+  width: 100%;
+}
+
+@media (max-width: 1024px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .app-sidebar {
+    position: static;
+  }
+}
+
+@media (max-width: 720px) {
+  .app {
+    padding: clamp(1rem, 6vw, 2rem);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dist"
   ],
   "scripts": {
+    "dev": "vite --config vite.config.ts",
     "build": "tsc && bun build ./src/index.ts --outdir dist --target bun --sourcemap --external react --external react-dom --external react/jsx-runtime",
     "typecheck": "tsc --noEmit",
     "test": "bun test"
@@ -24,10 +25,14 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "react": "^18.3.1"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.4",
-    "typescript": "^5.6.3"
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.2",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "mosaic-ui",
+  "version": "0.1.0",
+  "description": "An ergonomic, accessible React UI framework built with Bun.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc && bun build ./src/index.ts --outdir dist --target bun --sourcemap --external react --external react-dom --external react/jsx-runtime",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "keywords": [
+    "react",
+    "ui",
+    "design-system",
+    "accessibility",
+    "bun"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.4",
+    "typescript": "^5.6.3"
+  }
+}

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,0 +1,69 @@
+import { forwardRef, useMemo, useState, type HTMLAttributes } from "react";
+import { cx } from "../utils/cx";
+
+export type AvatarSize = "sm" | "md" | "lg";
+export type AvatarShape = "circle" | "square";
+
+export interface AvatarProps extends HTMLAttributes<HTMLDivElement> {
+  src?: string;
+  alt?: string;
+  name?: string;
+  fallback?: string;
+  size?: AvatarSize;
+  shape?: AvatarShape;
+}
+
+const getInitials = (name?: string, fallback?: string) => {
+  if (fallback) return fallback;
+  if (!name) return "";
+  const parts = name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (parts.length === 0) return "";
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  const first = parts[0] ?? "";
+  const last = parts[parts.length - 1] ?? "";
+  return `${first[0] ?? ""}${last[0] ?? ""}`.toUpperCase();
+};
+
+export const Avatar = forwardRef<HTMLDivElement, AvatarProps>(
+  (
+    { src, alt = "", name, fallback, size = "md", shape = "circle", className, children, ...rest },
+    ref,
+  ) => {
+    const [status, setStatus] = useState<"idle" | "loaded" | "error">(src ? "idle" : "error");
+
+    const initials = useMemo(() => getInitials(name, fallback), [name, fallback]);
+
+    const showFallback = !src || status === "error";
+
+    return (
+      <div
+        ref={ref}
+        className={cx("mosaic-avatar", className)}
+        data-size={size}
+        data-shape={shape}
+        data-loaded={status === "loaded" ? "true" : undefined}
+        {...rest}
+      >
+        {src && !showFallback ? (
+          <img
+            className="mosaic-avatar__image"
+            src={src}
+            alt={alt}
+            onLoad={() => setStatus("loaded")}
+            onError={() => setStatus("error")}
+          />
+        ) : null}
+        {showFallback ? (
+          <span className="mosaic-avatar__fallback" aria-hidden={children ? undefined : "true"}>
+            {children ?? (initials || "")}
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+Avatar.displayName = "Avatar";

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,0 +1,109 @@
+import { forwardRef, type CSSProperties, type HTMLAttributes, type ReactNode } from "react";
+import { getCssVar } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type BadgeTone = "neutral" | "primary" | "success" | "warning" | "danger";
+type BadgeVariant = "solid" | "soft" | "outline";
+
+type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
+  tone?: BadgeTone;
+  variant?: BadgeVariant;
+  leadingIcon?: ReactNode;
+  trailingIcon?: ReactNode;
+};
+
+const toneTokens: Record<BadgeTone, Record<string, string>> = {
+  primary: {
+    color: getCssVar("color-primary"),
+    contrast: getCssVar("color-primary-contrast"),
+    soft: getCssVar("color-primary-soft"),
+    border: getCssVar("color-primary-border"),
+  },
+  neutral: {
+    color: getCssVar("color-neutral"),
+    contrast: getCssVar("color-neutral-contrast"),
+    soft: getCssVar("color-neutral-soft"),
+    border: getCssVar("color-neutral-border"),
+  },
+  success: {
+    color: getCssVar("color-success"),
+    contrast: getCssVar("color-success-contrast"),
+    soft: getCssVar("color-success-soft"),
+    border: getCssVar("color-success-border"),
+  },
+  warning: {
+    color: getCssVar("color-warning"),
+    contrast: getCssVar("color-warning-contrast"),
+    soft: getCssVar("color-warning-soft"),
+    border: getCssVar("color-warning-border"),
+  },
+  danger: {
+    color: getCssVar("color-danger"),
+    contrast: getCssVar("color-danger-contrast"),
+    soft: getCssVar("color-danger-soft"),
+    border: getCssVar("color-danger-border"),
+  },
+};
+
+const variantTokens = (tone: BadgeTone, variant: BadgeVariant) => {
+  const palette = toneTokens[tone];
+  switch (variant) {
+    case "soft":
+      return {
+        "--mosaic-badge-bg": palette.soft,
+        "--mosaic-badge-fg": palette.color,
+        "--mosaic-badge-border": palette.border,
+      };
+    case "outline":
+      return {
+        "--mosaic-badge-bg": "transparent",
+        "--mosaic-badge-fg": palette.color,
+        "--mosaic-badge-border": palette.color,
+      };
+    case "solid":
+    default:
+      return {
+        "--mosaic-badge-bg": palette.color,
+        "--mosaic-badge-fg": palette.contrast,
+        "--mosaic-badge-border": palette.color,
+      };
+  }
+};
+
+export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
+  (
+    {
+      tone = "neutral",
+      variant = "soft",
+      leadingIcon,
+      trailingIcon,
+      className,
+      style,
+      children,
+      ...rest
+    },
+    ref,
+  ) => {
+    const styles: CSSProperties = {
+      ...(style as CSSProperties | undefined),
+      ...variantTokens(tone, variant),
+    };
+
+    return (
+      <span
+        ref={ref}
+        className={cx("mosaic-badge", className)}
+        data-tone={tone}
+        data-variant={variant}
+        style={styles}
+        {...rest}
+      >
+        {leadingIcon ? <span className="mosaic-badge__icon" aria-hidden="true">{leadingIcon}</span> : null}
+        <span className="mosaic-badge__label">{children}</span>
+        {trailingIcon ? <span className="mosaic-badge__icon" aria-hidden="true">{trailingIcon}</span> : null}
+      </span>
+    );
+  },
+);
+
+Badge.displayName = "Badge";

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,184 @@
+import {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+  type CSSProperties,
+} from "react";
+import { getCssVar } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type ButtonVariant = "solid" | "soft" | "outline" | "ghost";
+type ButtonTone = "primary" | "neutral" | "success" | "warning" | "danger";
+type ButtonSize = "sm" | "md" | "lg";
+
+const toneStyles: Record<ButtonTone, Record<string, string>> = {
+  primary: {
+    color: getCssVar("color-primary"),
+    contrast: getCssVar("color-primary-contrast"),
+    soft: getCssVar("color-primary-soft"),
+    border: getCssVar("color-primary-border"),
+  },
+  neutral: {
+    color: getCssVar("color-neutral"),
+    contrast: getCssVar("color-neutral-contrast"),
+    soft: getCssVar("color-neutral-soft"),
+    border: getCssVar("color-neutral-border"),
+  },
+  success: {
+    color: getCssVar("color-success"),
+    contrast: getCssVar("color-success-contrast"),
+    soft: getCssVar("color-success-soft"),
+    border: getCssVar("color-success-border"),
+  },
+  warning: {
+    color: getCssVar("color-warning"),
+    contrast: getCssVar("color-warning-contrast"),
+    soft: getCssVar("color-warning-soft"),
+    border: getCssVar("color-warning-border"),
+  },
+  danger: {
+    color: getCssVar("color-danger"),
+    contrast: getCssVar("color-danger-contrast"),
+    soft: getCssVar("color-danger-soft"),
+    border: getCssVar("color-danger-border"),
+  },
+};
+
+const sizeVars: Record<ButtonSize, Record<string, string>> = {
+  sm: {
+    "--mosaic-button-padding-y": "calc(var(--mosaic-spacing-xs) + 0.1rem)",
+    "--mosaic-button-padding-x": "calc(var(--mosaic-spacing-sm) + 0.1rem)",
+    "--mosaic-button-font-size": getCssVar("text-size-sm"),
+    "--mosaic-button-size-adjust": "-0.25rem",
+  },
+  md: {
+    "--mosaic-button-padding-y": "var(--mosaic-spacing-sm)",
+    "--mosaic-button-padding-x": "calc(var(--mosaic-spacing-md) + 0.125rem)",
+    "--mosaic-button-font-size": getCssVar("text-size-md"),
+    "--mosaic-button-size-adjust": "0rem",
+  },
+  lg: {
+    "--mosaic-button-padding-y": "calc(var(--mosaic-spacing-md) - 0.05rem)",
+    "--mosaic-button-padding-x": "calc(var(--mosaic-spacing-lg) - 0.1rem)",
+    "--mosaic-button-font-size": getCssVar("text-size-lg"),
+    "--mosaic-button-size-adjust": "0.25rem",
+  },
+};
+
+const toneVars = (tone: ButtonTone, variant: ButtonVariant): Record<string, string> => {
+  const palette = toneStyles[tone];
+  switch (variant) {
+    case "solid":
+      return {
+        "--mosaic-button-bg": palette.color,
+        "--mosaic-button-fg": palette.contrast,
+        "--mosaic-button-border": "transparent",
+        "--mosaic-button-bg-hover": palette.border,
+        "--mosaic-button-bg-active": palette.color,
+        "--mosaic-button-border-hover": "transparent",
+      };
+    case "soft":
+      return {
+        "--mosaic-button-bg": palette.soft,
+        "--mosaic-button-fg": palette.color,
+        "--mosaic-button-border": palette.border,
+        "--mosaic-button-bg-hover": palette.border,
+        "--mosaic-button-bg-active": palette.color,
+        "--mosaic-button-border-hover": palette.color,
+      };
+    case "outline":
+      return {
+        "--mosaic-button-bg": "transparent",
+        "--mosaic-button-fg": palette.color,
+        "--mosaic-button-border": palette.color,
+        "--mosaic-button-bg-hover": palette.soft,
+        "--mosaic-button-bg-active": palette.border,
+        "--mosaic-button-border-hover": palette.border,
+      };
+    case "ghost":
+    default:
+      return {
+        "--mosaic-button-bg": "transparent",
+        "--mosaic-button-fg": palette.color,
+        "--mosaic-button-border": "transparent",
+        "--mosaic-button-bg-hover": palette.soft,
+        "--mosaic-button-bg-active": palette.border,
+        "--mosaic-button-border-hover": palette.border,
+      };
+  }
+};
+
+export interface ButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "color"> {
+  variant?: ButtonVariant;
+  tone?: ButtonTone;
+  size?: ButtonSize;
+  leadingIcon?: ReactNode;
+  trailingIcon?: ReactNode;
+  isLoading?: boolean;
+  loadingText?: string;
+  fullWidth?: boolean;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      variant = "solid",
+      tone = "primary",
+      size = "md",
+      leadingIcon,
+      trailingIcon,
+      isLoading = false,
+      loadingText,
+      className,
+      disabled,
+      fullWidth = false,
+      children,
+      type = "button",
+      style: inlineStyle,
+      ...rest
+    },
+    ref,
+  ) => {
+    const paletteVars = toneVars(tone, variant);
+    const sizeStyles = sizeVars[size];
+    const styles: CSSProperties = { ...(inlineStyle as CSSProperties | undefined) };
+    Object.assign(styles, paletteVars, sizeStyles);
+
+    const isDisabled = disabled || isLoading;
+    const showLeading = Boolean(leadingIcon) && !isLoading;
+    const showTrailing = Boolean(trailingIcon) && !isLoading;
+    const label = isLoading && loadingText ? loadingText : children;
+
+    return (
+      <button
+        ref={ref}
+        type={type}
+        data-variant={variant}
+        data-tone={tone}
+        data-size={size}
+        data-full-width={fullWidth ? "true" : undefined}
+        data-loading={isLoading ? "true" : undefined}
+        className={cx("mosaic-button", className)}
+        style={styles}
+        disabled={isDisabled}
+        aria-busy={isLoading || undefined}
+        aria-live={isLoading ? "polite" : undefined}
+        {...rest}
+      >
+        {isLoading ? (
+          <span className="mosaic-button__spinner" aria-hidden="true" />
+        ) : showLeading ? (
+          <span aria-hidden="true">{leadingIcon}</span>
+        ) : null}
+        <span className="mosaic-button__label">{label}</span>
+        {showTrailing ? <span aria-hidden="true">{trailingIcon}</span> : null}
+        {isLoading && !loadingText ? (
+          <span className="mosaic-visually-hidden">Loading</span>
+        ) : null}
+      </button>
+    );
+  },
+);
+
+Button.displayName = "Button";

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,100 @@
+import {
+  forwardRef,
+  type CSSProperties,
+  type HTMLAttributes,
+} from "react";
+import { getCssVar } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type CardTone = "default" | "primary" | "neutral" | "success" | "warning" | "danger";
+type CardPadding = "none" | "sm" | "md" | "lg";
+type ShadowSize = "sm" | "md" | "lg";
+type ShadowToken = `shadow-${ShadowSize}`;
+
+const toneStyles: Record<CardTone, Record<string, string>> = {
+  default: {},
+  primary: {
+    "--mosaic-card-bg": getCssVar("color-primary-soft"),
+    "--mosaic-card-border": getCssVar("color-primary-border"),
+    "--mosaic-card-fg": getCssVar("color-text"),
+  },
+  neutral: {
+    "--mosaic-card-bg": getCssVar("color-neutral-soft"),
+    "--mosaic-card-border": getCssVar("color-neutral-border"),
+    "--mosaic-card-fg": getCssVar("color-text"),
+  },
+  success: {
+    "--mosaic-card-bg": getCssVar("color-success-soft"),
+    "--mosaic-card-border": getCssVar("color-success-border"),
+    "--mosaic-card-fg": getCssVar("color-text"),
+  },
+  warning: {
+    "--mosaic-card-bg": getCssVar("color-warning-soft"),
+    "--mosaic-card-border": getCssVar("color-warning-border"),
+    "--mosaic-card-fg": getCssVar("color-text"),
+  },
+  danger: {
+    "--mosaic-card-bg": getCssVar("color-danger-soft"),
+    "--mosaic-card-border": getCssVar("color-danger-border"),
+    "--mosaic-card-fg": getCssVar("color-text"),
+  },
+};
+
+const paddingMap: Record<CardPadding, string> = {
+  none: "0",
+  sm: "var(--mosaic-spacing-md)",
+  md: "var(--mosaic-spacing-lg)",
+  lg: "calc(var(--mosaic-spacing-lg) * 1.5)",
+};
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  tone?: CardTone;
+  elevated?: boolean;
+  hoverable?: boolean;
+  padding?: CardPadding;
+  shadow?: "sm" | "md" | "lg";
+}
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  (
+    {
+      tone = "default",
+      elevated = false,
+      hoverable = false,
+      padding = "md",
+      shadow,
+      className,
+      style: inlineStyle,
+      ...rest
+    },
+    ref,
+  ) => {
+    const toneVars = toneStyles[tone];
+    const styles: CSSProperties = { ...(inlineStyle as CSSProperties | undefined) };
+    Object.assign(styles, toneVars, {
+      "--mosaic-card-padding": paddingMap[padding],
+    });
+
+    if (shadow) {
+      const token: ShadowToken = `shadow-${shadow}`;
+      Object.assign(styles, {
+        "--mosaic-card-shadow": getCssVar(token),
+        "--mosaic-card-shadow-hover": getCssVar(token),
+      });
+    }
+
+    return (
+      <div
+        ref={ref}
+        data-tone={tone === "default" ? undefined : tone}
+        data-hoverable={hoverable ? "true" : undefined}
+        data-elevated={elevated ? "true" : undefined}
+        className={cx("mosaic-card", className)}
+        style={styles}
+        {...rest}
+      />
+    );
+  },
+);
+
+Card.displayName = "Card";

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,0 +1,58 @@
+import {
+  forwardRef,
+  useEffect,
+  useRef,
+  type InputHTMLAttributes,
+  type MutableRefObject,
+  type ReactNode,
+} from "react";
+import { cx } from "../utils/cx";
+
+export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "type"> {
+  description?: ReactNode;
+  indeterminate?: boolean;
+}
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ children, description, indeterminate = false, className, ...rest }, ref) => {
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    useEffect(() => {
+      if (inputRef.current) {
+        inputRef.current.indeterminate = indeterminate;
+      }
+    }, [indeterminate]);
+
+    const setRef = (node: HTMLInputElement | null) => {
+      inputRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        (ref as MutableRefObject<HTMLInputElement | null>).current = node;
+      }
+    };
+
+    return (
+      <label className={cx("mosaic-checkbox", className)}>
+        <span className="mosaic-checkbox__control">
+          <input
+            {...rest}
+            ref={setRef}
+            type="checkbox"
+            className="mosaic-checkbox__input"
+            aria-checked={
+              indeterminate ? "mixed" : rest.checked !== undefined ? rest.checked : undefined
+            }
+          />
+          <span className="mosaic-checkbox__indicator" aria-hidden="true" />
+        </span>
+        <span className="mosaic-checkbox__content">
+          {children ? <span className="mosaic-checkbox__label">{children}</span> : null}
+          {description ? <span className="mosaic-checkbox__description">{description}</span> : null}
+        </span>
+      </label>
+    );
+  },
+);
+
+Checkbox.displayName = "Checkbox";

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -1,0 +1,248 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useId,
+  forwardRef,
+  type ChangeEvent,
+  type InputHTMLAttributes,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MutableRefObject,
+} from "react";
+import { cx } from "../utils/cx";
+import { useControllableState } from "../utils/use-controllable-state";
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+}
+
+export interface ComboboxProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "defaultValue" | "onChange"> {
+  options: ComboboxOption[];
+  value?: string | null;
+  defaultValue?: string | null;
+  onValueChange?: (value: string | null) => void;
+  onInputChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  emptyMessage?: string;
+  clearable?: boolean;
+}
+
+export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
+  (
+    {
+      options,
+      value: valueProp,
+      defaultValue = null,
+      onValueChange,
+      onInputChange,
+      emptyMessage = "No results",
+      clearable = false,
+      className,
+      disabled,
+      ...rest
+    },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const listboxId = rest.id ? `${rest.id}-listbox` : undefined;
+    const [selectedValue, setSelectedValue] = useControllableState<string | null>({
+      value: valueProp === undefined ? undefined : valueProp,
+      defaultValue,
+      onChange: (next) => onValueChange?.(next),
+    });
+    const [open, setOpen] = useState(false);
+    const [inputValue, setInputValue] = useState("");
+    const [highlightedIndex, setHighlightedIndex] = useState(0);
+    const listRef = useRef<HTMLDivElement | null>(null);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    const mergedRef = (node: HTMLInputElement | null) => {
+      inputRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        (ref as MutableRefObject<HTMLInputElement | null>).current = node;
+      }
+    };
+
+    const selectedOption = useMemo(
+      () => options.find((option) => option.value === selectedValue) ?? null,
+      [options, selectedValue],
+    );
+
+    useEffect(() => {
+      if (!open) {
+        setInputValue(selectedOption?.label ?? "");
+      }
+    }, [selectedOption, open]);
+
+    const filteredOptions = useMemo(() => {
+      const query = inputValue.trim().toLowerCase();
+      if (!query) return options;
+      return options.filter((option) =>
+        option.label.toLowerCase().includes(query) || option.value.toLowerCase().includes(query),
+      );
+    }, [options, inputValue]);
+
+    useEffect(() => {
+      if (!open) return;
+      const firstEnabled = filteredOptions.findIndex((option) => !option.disabled);
+      setHighlightedIndex(firstEnabled === -1 ? 0 : firstEnabled);
+    }, [filteredOptions, open]);
+
+    const selectOption = (option: ComboboxOption | null) => {
+      if (option?.disabled) return;
+      setSelectedValue(option ? option.value : null);
+      setInputValue(option?.label ?? "");
+      setOpen(false);
+    };
+
+    const handleKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+      rest.onKeyDown?.(event);
+      if (event.defaultPrevented) return;
+      if (!open && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+        event.preventDefault();
+        setOpen(true);
+        return;
+      }
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setHighlightedIndex((index) => {
+          let next = index;
+          for (let i = 0; i < filteredOptions.length; i += 1) {
+            next = (next + 1) % filteredOptions.length;
+            if (!filteredOptions[next]?.disabled) break;
+          }
+          return next;
+        });
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setHighlightedIndex((index) => {
+          let next = index;
+          for (let i = 0; i < filteredOptions.length; i += 1) {
+            next = (next - 1 + filteredOptions.length) % filteredOptions.length;
+            if (!filteredOptions[next]?.disabled) break;
+          }
+          return next;
+        });
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        const option = filteredOptions[highlightedIndex];
+        if (option && !option.disabled) {
+          selectOption(option);
+        }
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+      }
+    };
+
+    const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+      rest.onBlur?.(event);
+      requestAnimationFrame(() => {
+        const active = document.activeElement;
+        if (!listRef.current || !listRef.current.contains(active)) {
+          setOpen(false);
+          setInputValue(selectedOption?.label ?? "");
+        }
+      });
+    };
+
+    const handleClear = () => {
+      selectOption(null);
+      inputRef.current?.focus();
+    };
+
+    const listboxUniqueId = listboxId ?? `${generatedId}-listbox`;
+    const activeOption = filteredOptions[highlightedIndex];
+
+    return (
+      <div className="mosaic-combobox">
+        <div className="mosaic-combobox__control">
+          <input
+            {...rest}
+            ref={mergedRef}
+            type="text"
+            className={cx("mosaic-input", "mosaic-combobox__input", className)}
+            value={inputValue}
+            onFocus={(event) => {
+              rest.onFocus?.(event);
+              if (!disabled) {
+                setOpen(true);
+              }
+            }}
+            onChange={(event) => {
+              onInputChange?.(event);
+              setInputValue(event.target.value);
+              setOpen(true);
+            }}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            role="combobox"
+            aria-expanded={open}
+            aria-controls={listboxUniqueId}
+            aria-autocomplete="list"
+            aria-activedescendant={open && activeOption ? `${listboxUniqueId}-${highlightedIndex}` : undefined}
+            disabled={disabled}
+          />
+          {clearable && selectedValue ? (
+            <button
+              type="button"
+              className="mosaic-combobox__clear"
+              onClick={handleClear}
+              aria-label="Clear selection"
+            >
+              ×
+            </button>
+          ) : null}
+        </div>
+        {open ? (
+          <div
+            ref={listRef}
+            className="mosaic-combobox__list"
+            id={listboxUniqueId}
+            role="listbox"
+          >
+            {filteredOptions.length === 0 ? (
+              <div className="mosaic-combobox__empty" role="option" aria-disabled="true">
+                {emptyMessage}
+              </div>
+            ) : (
+              filteredOptions.map((option, index) => {
+                const isActive = index === highlightedIndex;
+                const isSelected = option.value === selectedValue;
+                return (
+                  <div
+                    key={option.value}
+                    id={`${listboxUniqueId}-${index}`}
+                    role="option"
+                    aria-selected={isSelected}
+                    className={cx("mosaic-combobox__option", {
+                      "mosaic-combobox__option--active": isActive,
+                      "mosaic-combobox__option--selected": isSelected,
+                      "mosaic-combobox__option--disabled": option.disabled,
+                    })}
+                    onMouseEnter={() => setHighlightedIndex(index)}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => selectOption(option)}
+                  >
+                    <span className="mosaic-combobox__option-label">{option.label}</span>
+                    {option.description ? (
+                      <span className="mosaic-combobox__option-description">{option.description}</span>
+                    ) : null}
+                  </div>
+                );
+              })
+            )}
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+Combobox.displayName = "Combobox";

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,291 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PropsWithChildren,
+} from "react";
+import { Dialog } from "./Dialog";
+import { useShortcuts } from "../shortcuts/ShortcutsProvider";
+import { cx } from "../utils/cx";
+
+interface CommandPaletteContextValue {
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  isOpen: boolean;
+}
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue | undefined>(undefined);
+
+export interface CommandPaletteProps extends PropsWithChildren {
+  placeholder?: string;
+  emptyMessage?: string;
+  title?: string;
+  maxResults?: number;
+}
+
+export const CommandPalette = ({
+  children,
+  placeholder = "Search commands…",
+  emptyMessage = "No results found",
+  title = "Command palette",
+  maxResults = 50,
+}: CommandPaletteProps) => {
+  const { shortcuts, formatShortcut, setPaletteApi } = useShortcuts();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputId = useId();
+  const listboxId = useId();
+
+  const commands = useMemo(() => {
+    const unique = new Map<string, typeof shortcuts[number]>();
+    shortcuts.forEach((shortcut) => {
+      if (shortcut.hidden) return;
+      if (!shortcut.title) return;
+      unique.set(shortcut.id, shortcut);
+    });
+    return Array.from(unique.values());
+  }, [shortcuts]);
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filtered = useMemo(() => {
+    if (!normalizedQuery) {
+      return commands;
+    }
+    const terms = normalizedQuery.split(/\s+/).filter(Boolean);
+    if (terms.length === 0) {
+      return commands;
+    }
+    return commands.filter((command) => {
+      const haystack = [
+        command.title ?? "",
+        command.description ?? "",
+        command.section ?? "",
+        ...(command.keywords ?? []),
+      ]
+        .join(" ")
+        .toLowerCase();
+      return terms.every((term) => haystack.includes(term));
+    });
+  }, [commands, normalizedQuery]);
+
+  const limited = useMemo(() => filtered.slice(0, maxResults), [filtered, maxResults]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, typeof limited>();
+    limited.forEach((command) => {
+      const section = command.section ?? "General";
+      if (!map.has(section)) {
+        map.set(section, []);
+      }
+      map.get(section)!.push(command);
+    });
+    return Array.from(map.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([section, items]) => ({
+        section,
+        items: items.slice().sort((a, b) => (a.title ?? "").localeCompare(b.title ?? "")),
+      }));
+  }, [limited]);
+
+  const flat = useMemo(() => {
+    const entries: { group: string; command: typeof limited[number] }[] = [];
+    grouped.forEach((group) => {
+      group.items.forEach((command) => {
+        entries.push({ group: group.section, command });
+      });
+    });
+    return entries;
+  }, [grouped]);
+
+  const paletteShortcut = useMemo(() => formatShortcut("mod+k"), [formatShortcut]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setActiveIndex(0);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query, limited.length]);
+
+  const indexMap = useMemo(() => {
+    const map = new Map<string, number>();
+    flat.forEach((entry, index) => {
+      map.set(entry.command.id, index);
+    });
+    return map;
+  }, [flat]);
+
+  useEffect(() => {
+    setActiveIndex((index) => {
+      if (flat.length === 0) return 0;
+      return Math.min(index, flat.length - 1);
+    });
+  }, [flat.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    const active = flat[activeIndex];
+    if (!active) return;
+    const node = document.getElementById(`mosaic-command-${active.command.id}`);
+    if (node && "scrollIntoView" in node) {
+      node.scrollIntoView({ block: "nearest" });
+    }
+  }, [activeIndex, flat, open]);
+
+  useEffect(() => {
+    const api = {
+      open: () => setOpen(true),
+      close: () => setOpen(false),
+      toggle: () => setOpen((prev) => !prev),
+      isOpen: () => open,
+    };
+    setPaletteApi(api);
+    return () => setPaletteApi(null);
+  }, [open, setPaletteApi]);
+
+  const handleSelect = useCallback(
+    (command: typeof limited[number]) => {
+      setOpen(false);
+      setTimeout(() => {
+        command.run?.();
+      }, 0);
+    },
+    [],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveIndex((index) => Math.min(index + 1, flat.length - 1));
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveIndex((index) => Math.max(index - 1, 0));
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        setActiveIndex(0);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        setActiveIndex(Math.max(flat.length - 1, 0));
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        const active = flat[activeIndex];
+        if (active) {
+          handleSelect(active.command);
+        }
+      } else if (event.key === "Escape") {
+        setOpen(false);
+      }
+    },
+    [activeIndex, flat, handleSelect],
+  );
+
+  const contextValue = useMemo<CommandPaletteContextValue>(
+    () => ({
+      open: () => setOpen(true),
+      close: () => setOpen(false),
+      toggle: () => setOpen((prev) => !prev),
+      isOpen: open,
+    }),
+    [open],
+  );
+
+  const activeId = flat[activeIndex]?.command.id;
+
+  return (
+    <CommandPaletteContext.Provider value={contextValue}>
+      {children}
+      <Dialog
+        open={open}
+        onOpenChange={setOpen}
+        variant="command"
+        showCloseButton={false}
+        size="lg"
+        title={title}
+        bodyClassName="mosaic-command"
+      >
+        <div className="mosaic-command__search">
+          <label className="mosaic-command__label" htmlFor={inputId}>
+            <span className="mosaic-command__label-text">{placeholder}</span>
+            {paletteShortcut ? (
+              <span className="mosaic-command__shortcut">{paletteShortcut}</span>
+            ) : null}
+          </label>
+          <input
+            id={inputId}
+            className="mosaic-command__input"
+            placeholder={placeholder}
+            autoFocus
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleKeyDown}
+            role="combobox"
+            aria-expanded={open}
+            aria-controls={listboxId}
+            aria-activedescendant={activeId ? `mosaic-command-${activeId}` : undefined}
+            aria-autocomplete="list"
+          />
+        </div>
+        <div className="mosaic-command__results">
+          {flat.length === 0 ? (
+            <div className="mosaic-command__empty">{emptyMessage}</div>
+          ) : (
+            <div className="mosaic-command__list" role="listbox" id={listboxId}>
+              {grouped.map((group) => (
+                <div key={group.section} className="mosaic-command__section" role="presentation">
+                  <div className="mosaic-command__section-label">{group.section}</div>
+                  {group.items.map((command) => {
+                    const index = indexMap.get(command.id) ?? 0;
+                    const isActive = index === activeIndex;
+                    const shortcut = command.displayCombo ?? null;
+                    return (
+                      <div
+                        key={command.id}
+                        id={`mosaic-command-${command.id}`}
+                        role="option"
+                        aria-selected={isActive}
+                        className={cx("mosaic-command__option", {
+                          "mosaic-command__option--active": isActive,
+                        })}
+                        onMouseEnter={() => setActiveIndex(index)}
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => handleSelect(command)}
+                      >
+                        <div className="mosaic-command__option-main">
+                          <span className="mosaic-command__option-title">{command.title}</span>
+                          {command.description ? (
+                            <span className="mosaic-command__option-description">{command.description}</span>
+                          ) : null}
+                        </div>
+                        {shortcut ? <span className="mosaic-command__option-shortcut">{shortcut}</span> : null}
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </Dialog>
+    </CommandPaletteContext.Provider>
+  );
+};
+
+export const useCommandPalette = () => {
+  const context = useContext(CommandPaletteContext);
+  if (!context) {
+    throw new Error("useCommandPalette must be used within CommandPalette");
+  }
+  return context;
+};

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,0 +1,223 @@
+import {
+  cloneElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { Portal } from "../utils/Portal";
+import { cx } from "../utils/cx";
+import { ShortcutsContext } from "../shortcuts/ShortcutsProvider";
+
+export interface ContextMenuItem {
+  id?: string;
+  label?: ReactNode;
+  shortcut?: string | string[];
+  disabled?: boolean;
+  separator?: boolean;
+  onSelect?: () => void;
+  icon?: ReactNode;
+}
+
+export interface ContextMenuProps {
+  children: ReactElement;
+  items: ContextMenuItem[];
+  className?: string;
+  ariaLabel?: string;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const composeEventHandlers = <E extends { defaultPrevented: boolean }>(
+  originalHandler: ((event: E) => void) | undefined,
+  ourHandler: (event: E) => void,
+) => (event: E) => {
+  originalHandler?.(event);
+  if (!event.defaultPrevented) {
+    ourHandler(event);
+  }
+};
+
+type FormattedItem = ContextMenuItem & { shortcutLabel?: string };
+
+const focusableIndex = (items: FormattedItem[], start: number, direction: 1 | -1) => {
+  const count = items.length;
+  let index = start;
+  for (let i = 0; i < count; i += 1) {
+    index = (index + direction + count) % count;
+    const item = items[index];
+    if (!item.separator && !item.disabled) {
+      return index;
+    }
+  }
+  return start;
+};
+
+export const ContextMenu = ({ children, items, className, ariaLabel }: ContextMenuProps) => {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const shortcutsContext = useContext(ShortcutsContext);
+
+  const formattedItems = useMemo<FormattedItem[]>(() => {
+    return items.map((item) => {
+      if (!item.shortcut) {
+        return { ...item, shortcutLabel: undefined };
+      }
+      const label = shortcutsContext
+        ? shortcutsContext.formatShortcut(item.shortcut)
+        : Array.isArray(item.shortcut)
+          ? item.shortcut.join(" / ")
+          : item.shortcut;
+      return { ...item, shortcutLabel: label };
+    });
+  }, [items, shortcutsContext]);
+
+  const openMenu = (clientX: number, clientY: number) => {
+    setPosition({ x: clientX, y: clientY });
+    setOpen(true);
+    const firstEnabled = formattedItems.findIndex((item) => !item.separator && !item.disabled);
+    setActiveIndex(firstEnabled === -1 ? 0 : firstEnabled);
+  };
+
+  const closeMenu = () => {
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        closeMenu();
+      }
+    };
+    const handleScroll = () => closeMenu();
+    const handleResize = () => closeMenu();
+    document.addEventListener("mousedown", handleClick);
+    window.addEventListener("resize", handleResize);
+    window.addEventListener("scroll", handleScroll, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("scroll", handleScroll, true);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => menuRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    const maxX = clamp(position.x, 8, window.innerWidth - rect.width - 8);
+    const maxY = clamp(position.y, 8, window.innerHeight - rect.height - 8);
+    if (maxX !== position.x || maxY !== position.y) {
+      setPosition({ x: maxX, y: maxY });
+    }
+  }, [open, position.x, position.y]);
+
+  const handleContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault();
+    openMenu(event.clientX, event.clientY);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!open) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => focusableIndex(formattedItems, index, 1));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => focusableIndex(formattedItems, index, -1));
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      const first = formattedItems.findIndex((item) => !item.separator && !item.disabled);
+      if (first !== -1) setActiveIndex(first);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      const last = [...formattedItems].reverse().findIndex((item) => !item.separator && !item.disabled);
+      if (last !== -1) setActiveIndex(formattedItems.length - 1 - last);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      closeMenu();
+    } else if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      const item = formattedItems[activeIndex];
+      if (item && !item.disabled && !item.separator) {
+        item.onSelect?.();
+        closeMenu();
+      }
+    }
+  };
+
+  const triggerProps = {
+    onContextMenu: composeEventHandlers(children.props.onContextMenu, handleContextMenu),
+    onKeyDown: composeEventHandlers(children.props.onKeyDown, (event: ReactKeyboardEvent) => {
+      if (event.key === "ContextMenu" || (event.shiftKey && event.key === "F10")) {
+        event.preventDefault();
+        const rect = (event.target as HTMLElement).getBoundingClientRect();
+        openMenu(rect.left, rect.bottom);
+      }
+    }),
+  };
+
+  const content = (
+    <div
+      ref={menuRef}
+      className={cx("mosaic-context-menu", className)}
+      role="menu"
+      tabIndex={-1}
+      style={{ top: position.y, left: position.x }}
+      aria-label={ariaLabel}
+      onKeyDown={handleKeyDown}
+    >
+      {formattedItems.map((item, index) => {
+        if (item.separator) {
+          return <div key={item.id ?? `separator-${index}`} className="mosaic-context-menu__separator" role="separator" />;
+        }
+        const disabled = item.disabled ?? false;
+        const isActive = index === activeIndex;
+        return (
+          <button
+            key={item.id ?? index}
+            type="button"
+            className={cx("mosaic-context-menu__item", {
+              "mosaic-context-menu__item--active": isActive,
+            })}
+            role="menuitem"
+            data-disabled={disabled ? "true" : undefined}
+            tabIndex={-1}
+            disabled={disabled}
+            onMouseEnter={() => setActiveIndex(index)}
+            onClick={() => {
+              if (disabled) return;
+              item.onSelect?.();
+              closeMenu();
+            }}
+          >
+            {item.icon ? <span className="mosaic-context-menu__icon">{item.icon}</span> : null}
+            <span className="mosaic-context-menu__label">{item.label}</span>
+            {item.shortcutLabel ? (
+              <span className="mosaic-context-menu__shortcut">{item.shortcutLabel}</span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <>
+      {cloneElement(children, triggerProps)}
+      {open ? <Portal>{content}</Portal> : null}
+    </>
+  );
+};

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,0 +1,180 @@
+import { useMemo, useState, type PropsWithChildren, type ReactNode } from "react";
+import { cx } from "../utils/cx";
+
+export type SortDirection = "asc" | "desc";
+
+export interface DataTableColumn<T> {
+  key: string;
+  header: ReactNode;
+  accessor?: (row: T) => ReactNode;
+  sortAccessor?: (row: T) => string | number | Date | null;
+  sortable?: boolean;
+  align?: "left" | "center" | "right";
+  width?: string;
+}
+
+export interface DataTableProps<T> extends PropsWithChildren {
+  data: T[];
+  columns: DataTableColumn<T>[];
+  rowKey?: (row: T, index: number) => string;
+  className?: string;
+  caption?: ReactNode;
+  emptyMessage?: ReactNode;
+  defaultSort?: { columnKey: string; direction: SortDirection };
+  onSortChange?: (sort: { columnKey: string; direction: SortDirection } | null) => void;
+}
+
+const getSortValue = <T,>(row: T, column: DataTableColumn<T>) => {
+  if (column.sortAccessor) {
+    const result = column.sortAccessor(row);
+    return result instanceof Date ? result.getTime() : result;
+  }
+  if (column.accessor) {
+    const value = column.accessor(row);
+    return typeof value === "string" || typeof value === "number" ? value : String(value ?? "");
+  }
+  const key = column.key as keyof T;
+  const value = row[key];
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "string" || typeof value === "number") return value;
+  return value ? String(value) : "";
+};
+
+const compareValues = (a: unknown, b: unknown) => {
+  if (a === b) return 0;
+  if (a == null) return -1;
+  if (b == null) return 1;
+  if (typeof a === "number" && typeof b === "number") {
+    return a - b;
+  }
+  const aString = String(a);
+  const bString = String(b);
+  return aString.localeCompare(bString, undefined, { numeric: true, sensitivity: "base" });
+};
+
+export const DataTable = <T,>({
+  data,
+  columns,
+  rowKey,
+  className,
+  caption,
+  emptyMessage = "No records",
+  defaultSort,
+  onSortChange,
+}: DataTableProps<T>) => {
+  const [sort, setSort] = useState<{ columnKey: string; direction: SortDirection } | null>(
+    defaultSort ?? null,
+  );
+
+  const sortedData = useMemo(() => {
+    if (!sort) return data;
+    const column = columns.find((col) => col.key === sort.columnKey);
+    if (!column || !column.sortable) return data;
+    const copy = [...data];
+    copy.sort((a, b) => {
+      const valueA = getSortValue(a, column);
+      const valueB = getSortValue(b, column);
+      const comparison = compareValues(valueA, valueB);
+      return sort.direction === "asc" ? comparison : -comparison;
+    });
+    return copy;
+  }, [data, sort, columns]);
+
+  const toggleSort = (column: DataTableColumn<T>) => {
+    if (!column.sortable) return;
+    setSort((current) => {
+      const nextDirection: SortDirection =
+        !current || current.columnKey !== column.key
+          ? "asc"
+          : current.direction === "asc"
+            ? "desc"
+            : "asc";
+      const next = { columnKey: column.key, direction: nextDirection };
+      onSortChange?.(next);
+      return next;
+    });
+  };
+
+  const rows = sortedData;
+
+  return (
+    <div className={cx("mosaic-table-container", className)}>
+      <table className="mosaic-table">
+        {caption ? <caption className="mosaic-table__caption">{caption}</caption> : null}
+        <thead>
+          <tr>
+            {columns.map((column) => {
+              const isSorted = sort?.columnKey === column.key;
+              return (
+                <th
+                  key={column.key}
+                  scope="col"
+                  style={column.width ? { width: column.width } : undefined}
+                  className={cx(
+                    "mosaic-table__header",
+                    {
+                      "mosaic-table__header--sortable": column.sortable,
+                      "mosaic-table__header--sorted": isSorted,
+                    },
+                    column.align ? { [`mosaic-table__header--${column.align}`]: true } : undefined,
+                  )}
+                >
+                  {column.sortable ? (
+                    <button
+                      type="button"
+                      onClick={() => toggleSort(column)}
+                      className="mosaic-table__sort"
+                      aria-sort={
+                        isSorted ? (sort?.direction === "asc" ? "ascending" : "descending") : "none"
+                      }
+                    >
+                      <span>{column.header}</span>
+                      <span className="mosaic-table__sort-indicator" aria-hidden="true">
+                        {isSorted ? (sort?.direction === "asc" ? "▲" : "▼") : "↕"}
+                      </span>
+                    </button>
+                  ) : (
+                    column.header
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length === 0 ? (
+            <tr>
+              <td className="mosaic-table__empty" colSpan={columns.length}>
+                {emptyMessage}
+              </td>
+            </tr>
+          ) : (
+            rows.map((row, rowIndex) => {
+              const key = rowKey ? rowKey(row, rowIndex) : rowIndex;
+              return (
+                <tr key={key}>
+                  {columns.map((column) => {
+                    const content = column.accessor
+                      ? column.accessor(row)
+                      : (row as Record<string, unknown>)[column.key];
+                    return (
+                      <td
+                        key={column.key}
+                        className={cx(
+                          "mosaic-table__cell",
+                          column.align ? { [`mosaic-table__cell--${column.align}`]: true } : undefined,
+                        )}
+                      >
+                        {content as ReactNode}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,0 +1,12 @@
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { cx } from "../utils/cx";
+
+export interface DatePickerProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "type"> {}
+
+export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
+  ({ className, ...rest }, ref) => {
+    return <input ref={ref} type="date" className={cx("mosaic-input", "mosaic-date-picker", className)} {...rest} />;
+  },
+);
+
+DatePicker.displayName = "DatePicker";

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,0 +1,223 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  type PropsWithChildren,
+  type ReactNode,
+} from "react";
+import { Portal } from "../utils/Portal";
+import { cx } from "../utils/cx";
+
+const canUseDOM = typeof window !== "undefined" && typeof document !== "undefined";
+
+const focusableSelectors = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+const findFocusable = (container: HTMLElement | null) => {
+  if (!container) return [] as HTMLElement[];
+  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelectors)).filter((element) =>
+    !element.hasAttribute("data-mosaic-focus-guard"),
+  );
+};
+
+export type DialogVariant = "default" | "sheet" | "command";
+export type DialogSize = "sm" | "md" | "lg" | "xl" | "full";
+export type SheetSide = "left" | "right" | "bottom";
+
+export interface DialogProps extends PropsWithChildren {
+  open: boolean;
+  onOpenChange?: (open: boolean) => void;
+  title?: ReactNode;
+  description?: ReactNode;
+  footer?: ReactNode;
+  variant?: DialogVariant;
+  side?: SheetSide;
+  size?: DialogSize;
+  initialFocusRef?: React.RefObject<HTMLElement>;
+  showCloseButton?: boolean;
+  closeLabel?: string;
+  closeOnOverlayClick?: boolean;
+  className?: string;
+  bodyClassName?: string;
+}
+
+export const Dialog = ({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  footer,
+  variant = "default",
+  side = "right",
+  size = "md",
+  initialFocusRef,
+  showCloseButton = true,
+  closeLabel = "Close dialog",
+  closeOnOverlayClick = true,
+  className,
+  bodyClassName,
+}: DialogProps) => {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const lastFocusedRef = useRef<Element | null>(null);
+  const labelId = useId();
+  const descriptionId = useId();
+
+  const close = useCallback(() => {
+    onOpenChange?.(false);
+  }, [onOpenChange]);
+
+  useEffect(() => {
+    if (!open || !canUseDOM) return;
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    body.style.overflow = "hidden";
+    return () => {
+      body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !canUseDOM) return;
+    lastFocusedRef.current = document.activeElement;
+    const content = contentRef.current;
+    const initial = initialFocusRef?.current;
+    const focusables = findFocusable(content);
+    const target = initial ?? focusables[0] ?? content;
+    target?.focus({ preventScroll: true });
+    return () => {
+      const previous = lastFocusedRef.current as HTMLElement | null;
+      if (previous && typeof previous.focus === "function") {
+        previous.focus({ preventScroll: true });
+      }
+      lastFocusedRef.current = null;
+    };
+  }, [open, initialFocusRef]);
+
+  useEffect(() => {
+    if (!open || !canUseDOM) return;
+    const content = contentRef.current;
+    if (!content) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+        return;
+      }
+      if (event.key === "Tab") {
+        const focusables = findFocusable(content);
+        if (focusables.length === 0) {
+          event.preventDefault();
+          content.focus();
+          return;
+        }
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        const active = document.activeElement as HTMLElement | null;
+        if (!event.shiftKey && active === last) {
+          event.preventDefault();
+          first.focus();
+        } else if (event.shiftKey && active === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      }
+    };
+    content.addEventListener("keydown", handleKeyDown);
+    return () => {
+      content.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, close]);
+
+  const handleOverlayMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!closeOnOverlayClick) return;
+      if (event.target === event.currentTarget) {
+        close();
+      }
+    },
+    [close, closeOnOverlayClick],
+  );
+
+  const handleOverlayKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+      }
+    },
+    [close],
+  );
+
+  const labelledBy = title ? labelId : undefined;
+  const describedBy = description ? descriptionId : undefined;
+
+  const classes = useMemo(() => cx("mosaic-dialog", className), [className]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <Portal>
+      <div
+        ref={overlayRef}
+        className="mosaic-overlay"
+        data-variant={variant}
+        data-side={variant === "sheet" ? side : undefined}
+        onMouseDown={handleOverlayMouseDown}
+        onKeyDown={handleOverlayKeyDown}
+      >
+        <div
+          ref={contentRef}
+          className={classes}
+          data-open={open ? "true" : undefined}
+          data-variant={variant}
+          data-side={variant === "sheet" ? side : undefined}
+          data-size={size}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={labelledBy}
+          aria-describedby={describedBy}
+          tabIndex={-1}
+        >
+          {showCloseButton ? (
+            <button
+              type="button"
+              className="mosaic-dialog__close"
+              onClick={close}
+              aria-label={closeLabel}
+            >
+              ×
+            </button>
+          ) : null}
+          {title || description ? (
+            <header className="mosaic-dialog__header">
+              {title ? (
+                <h2 id={labelId} className="mosaic-dialog__title">
+                  {title}
+                </h2>
+              ) : null}
+              {description ? (
+                <p id={descriptionId} className="mosaic-dialog__description">
+                  {description}
+                </p>
+              ) : null}
+            </header>
+          ) : null}
+          <div className={cx("mosaic-dialog__body", bodyClassName)}>{children}</div>
+          {footer ? <footer className="mosaic-dialog__footer">{footer}</footer> : null}
+        </div>
+      </div>
+    </Portal>
+  );
+};

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -1,0 +1,101 @@
+import {
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  type HTMLAttributes,
+  type ReactNode,
+  useId,
+} from "react";
+import { cx } from "../utils/cx";
+import type { InputProps } from "./Input";
+
+const join = (...values: Array<string | undefined>) =>
+  values.filter(Boolean).join(" ");
+
+export interface FieldProps extends HTMLAttributes<HTMLDivElement> {
+  label?: ReactNode;
+  description?: ReactNode;
+  error?: ReactNode;
+  required?: boolean;
+  hint?: ReactNode;
+  id?: string;
+  children: ReactNode;
+}
+
+export const Field = forwardRef<HTMLDivElement, FieldProps>(
+  (
+    {
+      label,
+      description,
+      hint,
+      error,
+      required = false,
+      id,
+      children,
+      className,
+      ...rest
+    },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const fieldId = id ?? `mosaic-field-${generatedId}`;
+    const descriptionId = description ? `${fieldId}-description` : undefined;
+    const hintId = hint ? `${fieldId}-hint` : undefined;
+    const errorId = error ? `${fieldId}-error` : undefined;
+
+    let control = children;
+    if (isValidElement(children)) {
+      const childProps = children.props as Partial<InputProps> & {
+        id?: string;
+        "aria-describedby"?: string;
+        "aria-invalid"?: boolean | "true" | "false";
+      };
+      const describedBy = join(
+        childProps["aria-describedby"],
+        hintId,
+        descriptionId,
+        errorId,
+      );
+      control = cloneElement(children, {
+        id: childProps.id ?? fieldId,
+        "aria-describedby": describedBy || undefined,
+        "aria-invalid": error ? true : childProps["aria-invalid"],
+        required: required || childProps.required,
+      });
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cx("mosaic-field", className)}
+        data-invalid={error ? "true" : undefined}
+        {...rest}
+      >
+        {label ? (
+          <label className="mosaic-field__label" htmlFor={fieldId}>
+            {label}
+            {required ? <span className="mosaic-field__required">*</span> : null}
+          </label>
+        ) : null}
+        <div className="mosaic-field__control">{control}</div>
+        {hint ? (
+          <div className="mosaic-field__hint" id={hintId}>
+            {hint}
+          </div>
+        ) : null}
+        {description ? (
+          <div className="mosaic-field__description" id={descriptionId}>
+            {description}
+          </div>
+        ) : null}
+        {error ? (
+          <div className="mosaic-field__error" id={errorId}>
+            {error}
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+Field.displayName = "Field";

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,55 @@
+import {
+  forwardRef,
+  type CSSProperties,
+  type InputHTMLAttributes,
+} from "react";
+import { getCssVar } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type InputSize = "sm" | "md" | "lg";
+const sizeMap: Record<InputSize, Record<string, string>> = {
+  sm: {
+    "--mosaic-input-padding-y": "calc(var(--mosaic-spacing-xs) + 0.1rem)",
+    "--mosaic-input-padding-x": "var(--mosaic-spacing-sm)",
+    "--mosaic-input-font-size": getCssVar("text-size-sm"),
+  },
+  md: {
+    "--mosaic-input-padding-y": "var(--mosaic-spacing-sm)",
+    "--mosaic-input-padding-x": "var(--mosaic-spacing-md)",
+    "--mosaic-input-font-size": getCssVar("text-size-md"),
+  },
+  lg: {
+    "--mosaic-input-padding-y": "calc(var(--mosaic-spacing-md) - 0.05rem)",
+    "--mosaic-input-padding-x": "calc(var(--mosaic-spacing-lg) - 0.1rem)",
+    "--mosaic-input-font-size": getCssVar("text-size-lg"),
+  },
+};
+
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+  size?: InputSize;
+  invalid?: boolean;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    { size = "md", className, style: inlineStyle, invalid = false, ...rest },
+    ref,
+  ) => {
+    const sizeVars = sizeMap[size];
+    const styles: CSSProperties = { ...(inlineStyle as CSSProperties | undefined) };
+    Object.assign(styles, sizeVars);
+
+    return (
+      <input
+        ref={ref}
+        className={cx("mosaic-input", className)}
+        style={styles}
+        data-invalid={invalid ? "true" : undefined}
+        aria-invalid={invalid || undefined}
+        {...rest}
+      />
+    );
+  },
+);
+
+Input.displayName = "Input";

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,123 @@
+import { useMemo } from "react";
+import { Button } from "./Button";
+import { cx } from "../utils/cx";
+
+export interface PaginationProps {
+  page: number;
+  pageCount: number;
+  onPageChange?: (page: number) => void;
+  siblingCount?: number;
+  boundaryCount?: number;
+  className?: string;
+  disabled?: boolean;
+}
+
+type PageElement = number | "ellipsis";
+
+const createRange = (start: number, end: number): number[] => {
+  const range: number[] = [];
+  for (let i = start; i <= end; i += 1) {
+    range.push(i);
+  }
+  return range;
+};
+
+export const Pagination = ({
+  page,
+  pageCount,
+  onPageChange,
+  siblingCount = 1,
+  boundaryCount = 1,
+  className,
+  disabled = false,
+}: PaginationProps) => {
+  const items = useMemo<PageElement[]>(() => {
+    if (pageCount <= 0) return [];
+    const totalNumbers = siblingCount * 2 + boundaryCount * 2 + 3;
+    if (pageCount <= totalNumbers) {
+      return createRange(1, pageCount);
+    }
+
+    const startPage = Math.max(page - siblingCount, boundaryCount + 2);
+    const endPage = Math.min(page + siblingCount, pageCount - boundaryCount - 1);
+
+    const shouldShowLeftEllipsis = startPage > boundaryCount + 2;
+    const shouldShowRightEllipsis = endPage < pageCount - boundaryCount - 1;
+
+    const pages: PageElement[] = [];
+
+    pages.push(...createRange(1, boundaryCount));
+
+    if (shouldShowLeftEllipsis) {
+      pages.push("ellipsis");
+    } else {
+      pages.push(...createRange(boundaryCount + 1, startPage - 1));
+    }
+
+    pages.push(...createRange(startPage, endPage));
+
+    if (shouldShowRightEllipsis) {
+      pages.push("ellipsis");
+    } else {
+      pages.push(...createRange(endPage + 1, pageCount - boundaryCount));
+    }
+
+    pages.push(...createRange(Math.max(pageCount - boundaryCount + 1, boundaryCount + 1), pageCount));
+
+    return pages;
+  }, [page, pageCount, siblingCount, boundaryCount]);
+
+  const goToPage = (next: number) => {
+    if (next < 1 || next > pageCount || disabled) return;
+    onPageChange?.(next);
+  };
+
+  const canGoPrev = page > 1;
+  const canGoNext = page < pageCount;
+
+  return (
+    <nav className={cx("mosaic-pagination", className)} aria-label="Pagination">
+      <Button
+        variant="ghost"
+        tone="neutral"
+        onClick={() => goToPage(page - 1)}
+        disabled={!canGoPrev || disabled}
+      >
+        Previous
+      </Button>
+      <ul className="mosaic-pagination__list">
+        {items.map((item, index) => {
+          if (item === "ellipsis") {
+            return (
+              <li key={`ellipsis-${index}`} className="mosaic-pagination__ellipsis" aria-hidden="true">
+                …
+              </li>
+            );
+          }
+          const isActive = item === page;
+          return (
+            <li key={item}>
+              <Button
+                variant={isActive ? "solid" : "ghost"}
+                tone={isActive ? "primary" : "neutral"}
+                onClick={() => goToPage(item)}
+                aria-current={isActive ? "page" : undefined}
+                disabled={disabled}
+              >
+                {item}
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+      <Button
+        variant="ghost"
+        tone="neutral"
+        onClick={() => goToPage(page + 1)}
+        disabled={!canGoNext || disabled}
+      >
+        Next
+      </Button>
+    </nav>
+  );
+};

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -1,0 +1,51 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import { cx } from "../utils/cx";
+
+export interface ProgressProps extends HTMLAttributes<HTMLDivElement> {
+  value?: number;
+  max?: number;
+  label?: string;
+  indeterminate?: boolean;
+  showValue?: boolean;
+}
+
+export const Progress = forwardRef<HTMLDivElement, ProgressProps>(
+  (
+    { value = 0, max = 100, label, indeterminate = false, showValue = false, className, ...rest },
+    ref,
+  ) => {
+    const safeMax = max <= 0 ? 1 : max;
+    const clamped = Math.max(0, Math.min(value, safeMax));
+    const percentage = Math.round((clamped / safeMax) * 100);
+
+    return (
+      <div
+        ref={ref}
+        className={cx("mosaic-progress", className)}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={safeMax}
+        aria-valuenow={indeterminate ? undefined : clamped}
+        data-indeterminate={indeterminate ? "true" : undefined}
+        {...rest}
+      >
+        {label || showValue ? (
+          <div className="mosaic-progress__meta">
+            {label ? <span className="mosaic-progress__label">{label}</span> : null}
+            {showValue && !indeterminate ? (
+              <span className="mosaic-progress__value">{percentage}%</span>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="mosaic-progress__track" aria-hidden="true">
+          <div
+            className="mosaic-progress__indicator"
+            style={indeterminate ? undefined : { width: `${percentage}%` }}
+          />
+        </div>
+      </div>
+    );
+  },
+);
+
+Progress.displayName = "Progress";

--- a/src/components/Sheet.tsx
+++ b/src/components/Sheet.tsx
@@ -1,0 +1,10 @@
+import { type PropsWithChildren } from "react";
+import { Dialog, type DialogProps } from "./Dialog";
+
+export interface SheetProps extends Omit<DialogProps, "variant">, PropsWithChildren {
+  side?: "left" | "right" | "bottom";
+}
+
+export const Sheet = ({ side = "right", size = "lg", ...props }: SheetProps) => {
+  return <Dialog variant="sheet" side={side} size={size} {...props} />;
+};

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -1,0 +1,88 @@
+import {
+  forwardRef,
+  type CSSProperties,
+  type HTMLAttributes,
+} from "react";
+import { cx } from "../utils/cx";
+
+type StackDirection = "row" | "column";
+type StackGap = "none" | "xs" | "sm" | "md" | "lg";
+type StackAlign = "start" | "center" | "end" | "stretch";
+type StackJustify =
+  | "start"
+  | "center"
+  | "end"
+  | "space-between"
+  | "space-around"
+  | "space-evenly";
+
+const gapMap: Record<StackGap, string> = {
+  none: "0",
+  xs: "var(--mosaic-spacing-xs)",
+  sm: "var(--mosaic-spacing-sm)",
+  md: "var(--mosaic-spacing-md)",
+  lg: "var(--mosaic-spacing-lg)",
+};
+
+const alignMap: Record<StackAlign, CSSProperties["alignItems"]> = {
+  start: "flex-start",
+  center: "center",
+  end: "flex-end",
+  stretch: "stretch",
+};
+
+const justifyMap: Record<StackJustify, CSSProperties["justifyContent"]> = {
+  start: "flex-start",
+  center: "center",
+  end: "flex-end",
+  "space-between": "space-between",
+  "space-around": "space-around",
+  "space-evenly": "space-evenly",
+};
+
+export interface StackProps extends HTMLAttributes<HTMLDivElement> {
+  direction?: StackDirection;
+  gap?: StackGap;
+  align?: StackAlign;
+  justify?: StackJustify;
+  wrap?: boolean;
+}
+
+export const Stack = forwardRef<HTMLDivElement, StackProps>(
+  (
+    {
+      direction = "column",
+      gap = "md",
+      align = "stretch",
+      justify = "start",
+      wrap = false,
+      className,
+      style: inlineStyle,
+      ...rest
+    },
+    ref,
+  ) => {
+    const styles: CSSProperties = { ...(inlineStyle as CSSProperties | undefined) };
+    Object.assign(styles, {
+      "--mosaic-stack-gap": gapMap[gap],
+      "--mosaic-stack-align": alignMap[align] ?? "stretch",
+      "--mosaic-stack-justify": justifyMap[justify] ?? "flex-start",
+    });
+
+    if (wrap) {
+      styles.flexWrap = "wrap";
+    }
+
+    return (
+      <div
+        ref={ref}
+        data-direction={direction}
+        className={cx("mosaic-stack", className)}
+        style={styles}
+        {...rest}
+      />
+    );
+  },
+);
+
+Stack.displayName = "Stack";

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,0 +1,32 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
+import { cx } from "../utils/cx";
+
+export interface SwitchProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "type"> {
+  description?: ReactNode;
+}
+
+export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
+  ({ children, description, className, ...rest }, ref) => {
+    return (
+      <label className={cx("mosaic-switch", className)}>
+        <input
+          {...rest}
+          ref={ref}
+          type="checkbox"
+          role="switch"
+          className="mosaic-switch__input"
+          aria-checked={rest.checked}
+        />
+        <span className="mosaic-switch__track" aria-hidden="true">
+          <span className="mosaic-switch__thumb" />
+        </span>
+        <span className="mosaic-switch__content">
+          {children ? <span className="mosaic-switch__label">{children}</span> : null}
+          {description ? <span className="mosaic-switch__description">{description}</span> : null}
+        </span>
+      </label>
+    );
+  },
+);
+
+Switch.displayName = "Switch";

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,0 +1,90 @@
+import {
+  forwardRef,
+  type CSSProperties,
+  type HTMLAttributes,
+} from "react";
+import { getCssVar } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type TextElement = keyof HTMLElementTagNameMap;
+type TextVariant =
+  | "body"
+  | "muted"
+  | "subtle"
+  | "headline"
+  | "title"
+  | "label"
+  | "code"
+  | "caption";
+type TextTone =
+  | "default"
+  | "muted"
+  | "subtle"
+  | "primary"
+  | "success"
+  | "warning"
+  | "danger";
+
+const toneMap: Record<TextTone, string | null> = {
+  default: null,
+  muted: getCssVar("color-text-muted"),
+  subtle: getCssVar("color-text-subtle"),
+  primary: getCssVar("color-primary"),
+  success: getCssVar("color-success"),
+  warning: getCssVar("color-warning"),
+  danger: getCssVar("color-danger"),
+};
+
+export interface TextProps extends HTMLAttributes<HTMLElement> {
+  as?: TextElement;
+  variant?: TextVariant;
+  tone?: TextTone;
+  align?: "start" | "center" | "end" | "justify";
+  truncate?: boolean;
+}
+
+export const Text = forwardRef<HTMLElement, TextProps>(
+  (
+    {
+      as = "span",
+      variant = "body",
+      tone = "default",
+      align,
+      truncate = false,
+      className,
+      style: inlineStyle,
+      ...rest
+    },
+    ref,
+  ) => {
+    const Element = as as any;
+    const toneValue = toneMap[tone];
+    const styles: CSSProperties = { ...(inlineStyle as CSSProperties | undefined) };
+
+    if (toneValue) {
+      Object.assign(styles, { "--mosaic-text-color": toneValue });
+    }
+
+    if (align) {
+      styles.textAlign = align as CSSProperties["textAlign"];
+    }
+
+    if (truncate) {
+      styles.whiteSpace = "nowrap";
+      styles.overflow = "hidden";
+      styles.textOverflow = "ellipsis";
+    }
+
+    return (
+      <Element
+        ref={ref as any}
+        data-variant={variant}
+        className={cx("mosaic-text", className)}
+        style={styles}
+        {...rest}
+      />
+    );
+  },
+);
+
+Text.displayName = "Text";

--- a/src/components/ThemePanel.tsx
+++ b/src/components/ThemePanel.tsx
@@ -1,0 +1,120 @@
+import { useMemo } from "react";
+import { Button } from "./Button";
+import { Card } from "./Card";
+import { Field } from "./Field";
+import { Stack } from "./Stack";
+import { Text } from "./Text";
+import { useTheme } from "../theme/ThemeProvider";
+import type { Accent, Appearance, ColorVisionMode } from "../theme/types";
+
+const appearanceOptions: Appearance[] = ["light", "dark"];
+const accentOptions: Accent[] = [
+  "indigo",
+  "azure",
+  "violet",
+  "emerald",
+  "amber",
+  "rose",
+  "neutral",
+];
+const colorVisionOptions: ColorVisionMode[] = [
+  "normal",
+  "protanopia",
+  "deuteranopia",
+  "tritanopia",
+  "achromatopsia",
+];
+
+export const ThemePanel = () => {
+  const {
+    appearance,
+    accent,
+    colorVision,
+    highContrast,
+    reducedMotion,
+    setAppearance,
+    toggleAppearance,
+    setAccent,
+    setColorVision,
+    toggleHighContrast,
+    toggleReducedMotion,
+  } = useTheme();
+
+  const appearanceLabel = useMemo(() => {
+    return appearance === "light" ? "Light" : "Dark";
+  }, [appearance]);
+
+  return (
+    <Card tone="neutral" padding="lg" hoverable>
+      <Stack gap="md">
+        <Stack direction="row" align="center" justify="space-between">
+          <Text variant="title">Theme settings</Text>
+          <Button variant="outline" tone="neutral" onClick={toggleAppearance}>
+            Toggle {appearanceLabel}
+          </Button>
+        </Stack>
+        <Stack gap="sm">
+          <Field label="Appearance">
+            <select
+              className="mosaic-input"
+              value={appearance}
+              onChange={(event) => setAppearance(event.target.value as Appearance)}
+            >
+              {appearanceOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option.charAt(0).toUpperCase() + option.slice(1)}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Accent">
+            <select
+              className="mosaic-input"
+              value={accent}
+              onChange={(event) => setAccent(event.target.value as Accent)}
+            >
+              {accentOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option.charAt(0).toUpperCase() + option.slice(1)}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Color vision mode">
+            <select
+              className="mosaic-input"
+              value={colorVision}
+              onChange={(event) => setColorVision(event.target.value as ColorVisionMode)}
+            >
+              {colorVisionOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option.charAt(0).toUpperCase() + option.slice(1)}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </Stack>
+        <Stack direction="row" gap="sm" wrap>
+          <Button
+            variant={highContrast ? "solid" : "soft"}
+            tone={highContrast ? "danger" : "neutral"}
+            onClick={toggleHighContrast}
+          >
+            {highContrast ? "Disable" : "Enable"} high contrast
+          </Button>
+          <Button
+            variant={reducedMotion ? "solid" : "soft"}
+            tone={reducedMotion ? "warning" : "neutral"}
+            onClick={toggleReducedMotion}
+          >
+            {reducedMotion ? "Disable" : "Enable"} reduced motion
+          </Button>
+        </Stack>
+        <Text variant="caption" tone="subtle">
+          Mosaic adapts automatically to system preferences and exposes helpers for color vision,
+          high contrast, and motion reduction so you can ship inclusive interfaces.
+        </Text>
+      </Stack>
+    </Card>
+  );
+};

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,165 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PropsWithChildren,
+} from "react";
+import { Portal } from "../utils/Portal";
+import { cx } from "../utils/cx";
+
+export type ToastTone = "neutral" | "primary" | "success" | "warning" | "danger";
+
+export interface ToastAction {
+  label: string;
+  onAction: () => void;
+  altText?: string;
+}
+
+export interface ToastOptions {
+  id?: string;
+  title: string;
+  description?: string;
+  tone?: ToastTone;
+  duration?: number;
+  action?: ToastAction;
+}
+
+interface ToastInstance extends ToastOptions {
+  id: string;
+  tone: ToastTone;
+  createdAt: number;
+}
+
+export interface ToastProviderProps extends PropsWithChildren {
+  placement?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+  maxToasts?: number;
+  className?: string;
+}
+
+interface ToastContextValue {
+  toast: (options: ToastOptions) => string;
+  dismiss: (id: string) => void;
+  clear: () => void;
+  toasts: ToastInstance[];
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+let toastId = 0;
+const getToastId = () => {
+  toastId += 1;
+  return `toast-${toastId}`;
+};
+
+const DEFAULT_DURATION = 5000;
+
+export const ToastProvider = ({
+  children,
+  placement = "bottom-right",
+  maxToasts = 4,
+  className,
+}: ToastProviderProps) => {
+  const [toasts, setToasts] = useState<ToastInstance[]>([]);
+  const timers = useRef<Map<string, number>>(new Map());
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    const timeout = timers.current.get(id);
+    if (timeout) {
+      window.clearTimeout(timeout);
+      timers.current.delete(id);
+    }
+  }, []);
+
+  const toast = useCallback(
+    (options: ToastOptions) => {
+      const id = options.id ?? getToastId();
+      const tone = options.tone ?? "neutral";
+      setToasts((prev) => {
+        const next: ToastInstance[] = [...prev.filter((item) => item.id !== id), {
+          ...options,
+          id,
+          tone,
+          createdAt: Date.now(),
+        }];
+        if (next.length > maxToasts) {
+          next.splice(0, next.length - maxToasts);
+        }
+        return next;
+      });
+      if (options.duration !== 0) {
+        const timeout = window.setTimeout(() => dismiss(id), options.duration ?? DEFAULT_DURATION);
+        timers.current.set(id, timeout);
+      }
+      return id;
+    },
+    [dismiss, maxToasts],
+  );
+
+  const clear = useCallback(() => {
+    timers.current.forEach((timeout) => window.clearTimeout(timeout));
+    timers.current.clear();
+    setToasts([]);
+  }, []);
+
+  useEffect(() => () => clear(), [clear]);
+
+  const value = useMemo<ToastContextValue>(() => ({ toast, dismiss, clear, toasts }), [toast, dismiss, clear, toasts]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <Portal>
+        <div className={cx("mosaic-toast-viewport", className)} data-placement={placement}>
+          {toasts.map((toastItem) => (
+            <div key={toastItem.id} className={cx("mosaic-toast", `mosaic-toast--${toastItem.tone}`)} role="status" aria-live="polite">
+              <div className="mosaic-toast__body">
+                <div className="mosaic-toast__content">
+                  <span className="mosaic-toast__title">{toastItem.title}</span>
+                  {toastItem.description ? (
+                    <span className="mosaic-toast__description">{toastItem.description}</span>
+                  ) : null}
+                </div>
+                <div className="mosaic-toast__actions">
+                  {toastItem.action ? (
+                    <button
+                      type="button"
+                      className="mosaic-toast__action"
+                      onClick={() => {
+                        toastItem.action?.onAction();
+                        dismiss(toastItem.id);
+                      }}
+                      aria-label={toastItem.action.altText ?? toastItem.action.label}
+                    >
+                      {toastItem.action.label}
+                    </button>
+                  ) : null}
+                  <button
+                    type="button"
+                    className="mosaic-toast__close"
+                    onClick={() => dismiss(toastItem.id)}
+                    aria-label="Dismiss notification"
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Portal>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+};

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,234 @@
+import {
+  cloneElement,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
+} from "react";
+import { Portal } from "../utils/Portal";
+import { cx } from "../utils/cx";
+import { ShortcutsContext } from "../shortcuts/ShortcutsProvider";
+
+const canUseDOM = typeof window !== "undefined";
+
+type TooltipSide = "top" | "right" | "bottom" | "left";
+type TooltipAlign = "center" | "start" | "end";
+
+const composeEventHandlers = <E extends { defaultPrevented: boolean }>(
+  originalHandler: ((event: E) => void) | undefined,
+  ourHandler: (event: E) => void,
+) => {
+  return (event: E) => {
+    originalHandler?.(event);
+    if (!event.defaultPrevented) {
+      ourHandler(event);
+    }
+  };
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+export interface TooltipProps {
+  children: ReactElement;
+  label: React.ReactNode;
+  shortcut?: string | string[];
+  side?: TooltipSide;
+  align?: TooltipAlign;
+  delay?: number;
+  id?: string;
+  className?: string;
+}
+
+export const Tooltip = ({
+  children,
+  label,
+  shortcut,
+  side = "top",
+  align = "center",
+  delay = 120,
+  id,
+  className,
+}: TooltipProps) => {
+  const [visible, setVisible] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const showTimer = useRef<number>();
+  const hideTimer = useRef<number>();
+  const tooltipId = id ?? useId();
+  const shortcutsContext = useContext(ShortcutsContext);
+
+  const formattedShortcut = useMemo(() => {
+    if (!shortcut) return null;
+    const formatter = shortcutsContext?.formatShortcut;
+    if (formatter) {
+      return formatter(shortcut);
+    }
+    if (Array.isArray(shortcut)) {
+      return shortcut.join(" / ");
+    }
+    return shortcut;
+  }, [shortcut, shortcutsContext]);
+
+  const clearTimers = () => {
+    if (showTimer.current) {
+      window.clearTimeout(showTimer.current);
+      showTimer.current = undefined;
+    }
+    if (hideTimer.current) {
+      window.clearTimeout(hideTimer.current);
+      hideTimer.current = undefined;
+    }
+  };
+
+  const openTooltip = () => {
+    clearTimers();
+    showTimer.current = window.setTimeout(() => {
+      setVisible(true);
+    }, delay);
+  };
+
+  const closeTooltip = () => {
+    clearTimers();
+    hideTimer.current = window.setTimeout(() => {
+      setVisible(false);
+    }, 60);
+  };
+
+  useEffect(() => () => clearTimers(), []);
+
+  const computePosition = () => {
+    const trigger = triggerRef.current;
+    const tooltip = tooltipRef.current;
+    if (!trigger || !tooltip) return;
+    const rect = trigger.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const offset = 8;
+    let top = 0;
+    let left = 0;
+
+    switch (side) {
+      case "bottom":
+        top = rect.bottom + offset;
+        break;
+      case "left":
+        top = rect.top + rect.height / 2 - tooltipRect.height / 2;
+        left = rect.left - tooltipRect.width - offset;
+        break;
+      case "right":
+        top = rect.top + rect.height / 2 - tooltipRect.height / 2;
+        left = rect.right + offset;
+        break;
+      case "top":
+      default:
+        top = rect.top - tooltipRect.height - offset;
+        break;
+    }
+
+    if (side === "top" || side === "bottom") {
+      switch (align) {
+        case "start":
+          left = rect.left;
+          break;
+        case "end":
+          left = rect.right - tooltipRect.width;
+          break;
+        case "center":
+        default:
+          left = rect.left + rect.width / 2 - tooltipRect.width / 2;
+          break;
+      }
+    } else {
+      switch (align) {
+        case "start":
+          top = rect.top;
+          break;
+        case "end":
+          top = rect.bottom - tooltipRect.height;
+          break;
+        case "center":
+        default:
+          break;
+      }
+      if (side === "left") {
+        left = rect.left - tooltipRect.width - offset;
+      } else if (side === "right") {
+        left = rect.right + offset;
+      }
+    }
+
+    const viewWidth = window.innerWidth;
+    const viewHeight = window.innerHeight;
+    const clampedTop = clamp(top, 8, viewHeight - tooltipRect.height - 8);
+    const clampedLeft = clamp(left, 8, viewWidth - tooltipRect.width - 8);
+
+    setPosition({ top: clampedTop, left: clampedLeft });
+  };
+
+  useEffect(() => {
+    if (!visible || !canUseDOM) return;
+    computePosition();
+    const handleUpdate = () => computePosition();
+    window.addEventListener("scroll", handleUpdate, true);
+    window.addEventListener("resize", handleUpdate);
+    return () => {
+      window.removeEventListener("scroll", handleUpdate, true);
+      window.removeEventListener("resize", handleUpdate);
+    };
+  }, [visible, side, align]);
+
+  const setTrigger = (node: HTMLElement | null) => {
+    triggerRef.current = node;
+    const originalRef = (children as any).ref;
+    if (typeof originalRef === "function") {
+      originalRef(node);
+    } else if (originalRef && typeof originalRef === "object") {
+      originalRef.current = node;
+    }
+  };
+
+  const describedBy = children.props["aria-describedby"] as string | undefined;
+  const triggerProps = {
+    ref: setTrigger,
+    onMouseEnter: composeEventHandlers(children.props.onMouseEnter, openTooltip),
+    onMouseLeave: composeEventHandlers(children.props.onMouseLeave, closeTooltip),
+    onFocus: composeEventHandlers(children.props.onFocus, openTooltip),
+    onBlur: composeEventHandlers(children.props.onBlur, closeTooltip),
+    onKeyDown: composeEventHandlers(children.props.onKeyDown, (event: ReactKeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeTooltip();
+      }
+    }),
+    "aria-describedby": visible
+      ? [describedBy, tooltipId].filter(Boolean).join(" ")
+      : describedBy,
+  };
+
+  return (
+    <>
+      {cloneElement(children, triggerProps)}
+      {visible ? (
+        <Portal>
+          <div
+            ref={tooltipRef}
+            id={tooltipId}
+            role="tooltip"
+            className={cx("mosaic-tooltip", className)}
+            data-side={side}
+            data-align={align}
+            style={{ top: position.top, left: position.left }}
+          >
+            <span className="mosaic-tooltip__label">{label}</span>
+            {formattedShortcut ? (
+              <span className="mosaic-tooltip__shortcut">{formattedShortcut}</span>
+            ) : null}
+          </div>
+        </Portal>
+      ) : null}
+    </>
+  );
+};

--- a/src/components/VisuallyHidden.tsx
+++ b/src/components/VisuallyHidden.tsx
@@ -1,0 +1,10 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import { cx } from "../utils/cx";
+
+export const VisuallyHidden = forwardRef<HTMLSpanElement, HTMLAttributes<HTMLSpanElement>>(
+  ({ className, ...rest }, ref) => (
+    <span ref={ref} className={cx("mosaic-visually-hidden", className)} {...rest} />
+  ),
+);
+
+VisuallyHidden.displayName = "VisuallyHidden";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,33 @@
+export { Button } from "./components/Button";
+export { Card } from "./components/Card";
+export { Field } from "./components/Field";
+export { Input } from "./components/Input";
+export { Stack } from "./components/Stack";
+export { Text } from "./components/Text";
+export { ThemePanel } from "./components/ThemePanel";
+export { VisuallyHidden } from "./components/VisuallyHidden";
+
+export {
+  ThemeProvider,
+  useTheme,
+  useThemeValue,
+  getCssVar,
+} from "./theme/ThemeProvider";
+
+export type {
+  Accent,
+  Appearance,
+  ColorVisionMode,
+  ThemeContextValue,
+  ThemeOptions,
+  ThemeState,
+  ThemeTokens,
+  ThemeTokenName,
+} from "./theme/types";
+
+export {
+  createThemeTokens,
+  tokensToCssVariables,
+  tokenToVar,
+  toCssText,
+} from "./theme/color";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,21 @@ export { Stack } from "./components/Stack";
 export { Text } from "./components/Text";
 export { ThemePanel } from "./components/ThemePanel";
 export { VisuallyHidden } from "./components/VisuallyHidden";
+export { Avatar } from "./components/Avatar";
+export { Badge } from "./components/Badge";
+export { Checkbox } from "./components/Checkbox";
+export { Combobox } from "./components/Combobox";
+export { CommandPalette, useCommandPalette } from "./components/CommandPalette";
+export { ContextMenu } from "./components/ContextMenu";
+export { DataTable } from "./components/DataTable";
+export { DatePicker } from "./components/DatePicker";
+export { Dialog } from "./components/Dialog";
+export { Pagination } from "./components/Pagination";
+export { Progress } from "./components/Progress";
+export { Sheet } from "./components/Sheet";
+export { Switch } from "./components/Switch";
+export { ToastProvider, useToast } from "./components/Toast";
+export { Tooltip } from "./components/Tooltip";
 
 export {
   ThemeProvider,
@@ -13,6 +28,13 @@ export {
   useThemeValue,
   getCssVar,
 } from "./theme/ThemeProvider";
+
+export {
+  ShortcutsProvider,
+  useShortcuts,
+  useShortcut,
+  useCommand,
+} from "./shortcuts/ShortcutsProvider";
 
 export type {
   Accent,

--- a/src/shortcuts/ShortcutsProvider.tsx
+++ b/src/shortcuts/ShortcutsProvider.tsx
@@ -1,0 +1,409 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PropsWithChildren,
+} from "react";
+
+const isBrowser = typeof window !== "undefined";
+
+const isMacPlatform = () => {
+  if (!isBrowser) return false;
+  const platform = window.navigator.platform ?? "";
+  return /mac|iphone|ipad|ipod/i.test(platform);
+};
+
+const modifierOrder = ["ctrl", "meta", "alt", "shift"] as const;
+
+type Modifier = typeof modifierOrder[number];
+
+type NormalizedCombo = string;
+
+const normalizeKey = (key: string): string => {
+  const lower = key.toLowerCase();
+  switch (lower) {
+    case " ":
+    case "spacebar":
+      return "space";
+    case "escape":
+      return "esc";
+    case "arrowup":
+      return "arrowup";
+    case "arrowdown":
+      return "arrowdown";
+    case "arrowleft":
+      return "arrowleft";
+    case "arrowright":
+      return "arrowright";
+    case "enter":
+    case "return":
+      return "enter";
+    case "delete":
+    case "del":
+      return "delete";
+    case "backspace":
+      return "backspace";
+    case "tab":
+      return "tab";
+    default:
+      return lower;
+  }
+};
+
+const modifierAlias: Record<string, Modifier | "mod"> = {
+  cmd: "meta",
+  command: "meta",
+  meta: "meta",
+  win: "meta",
+  windows: "meta",
+  control: "ctrl",
+  ctrl: "ctrl",
+  option: "alt",
+  alt: "alt",
+  shift: "shift",
+};
+
+const sortModifiers = (modifiers: Set<Modifier>): Modifier[] => {
+  return modifierOrder.filter((modifier) => modifiers.has(modifier));
+};
+
+const expandCombo = (combo: string): NormalizedCombo[] => {
+  const parts = combo
+    .split("+")
+    .map((token) => token.trim())
+    .filter(Boolean)
+    .map((token) => token.toLowerCase());
+
+  const modifiers = new Set<Modifier>();
+  let key: string | undefined;
+  let hasMod = false;
+
+  parts.forEach((part) => {
+    if (part === "mod") {
+      hasMod = true;
+      return;
+    }
+    const alias = modifierAlias[part];
+    if (alias) {
+      if (alias === "mod") {
+        hasMod = true;
+        return;
+      }
+      modifiers.add(alias);
+      return;
+    }
+    key = normalizeKey(part);
+  });
+
+  if (!key) return [];
+
+  const combos: NormalizedCombo[] = [];
+  const base = sortModifiers(modifiers);
+
+  const buildCombo = (mods: Modifier[]) => {
+    return [...mods, key!].join("+");
+  };
+
+  if (hasMod) {
+    combos.push(buildCombo([...base, "meta"] as Modifier[]));
+    combos.push(buildCombo([...base, "ctrl"] as Modifier[]));
+  } else {
+    combos.push(buildCombo(base));
+  }
+
+  return Array.from(new Set(combos));
+};
+
+const normalizeCombo = (combo: string): NormalizedCombo[] => {
+  const trimmed = combo.trim();
+  if (!trimmed) return [];
+  return expandCombo(trimmed);
+};
+
+const eventToCombo = (event: KeyboardEvent): NormalizedCombo | null => {
+  const key = normalizeKey(event.key);
+  if (!key || modifierAlias[key] || key === "mod") return null;
+
+  const modifiers = new Set<Modifier>();
+  if (event.ctrlKey) modifiers.add("ctrl");
+  if (event.metaKey) modifiers.add("meta");
+  if (event.altKey) modifiers.add("alt");
+  if (event.shiftKey) modifiers.add("shift");
+
+  if (!event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
+    // do not trigger on plain keys in text inputs
+    return key.length === 1 ? key : key;
+  }
+
+  return [...sortModifiers(modifiers), key].join("+");
+};
+
+const isEditableElement = (element: EventTarget | null): element is HTMLElement => {
+  if (!element || !(element instanceof HTMLElement)) return false;
+  const tag = element.tagName;
+  return (
+    element.isContentEditable ||
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT"
+  );
+};
+
+export interface ShortcutConfig {
+  id?: string;
+  title?: string;
+  description?: string;
+  section?: string;
+  keywords?: string[];
+  combo?: string | string[];
+  run: (event?: KeyboardEvent) => void;
+  allowInInput?: boolean;
+  preventDefault?: boolean;
+  hidden?: boolean;
+}
+
+export interface RegisteredShortcut extends ShortcutConfig {
+  id: string;
+  combos: NormalizedCombo[];
+  displayCombo: string | null;
+  hidden: boolean;
+}
+
+export interface CommandPaletteApi {
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  isOpen: () => boolean;
+}
+
+interface ShortcutsContextValue {
+  registerShortcut: (config: ShortcutConfig) => () => void;
+  shortcuts: RegisteredShortcut[];
+  formatShortcut: (combo: string | string[]) => string;
+  isMac: boolean;
+  openPalette: () => void;
+  closePalette: () => void;
+  togglePalette: () => void;
+  setPaletteApi: (api: CommandPaletteApi | null) => void;
+}
+
+export const ShortcutsContext = createContext<ShortcutsContextValue | undefined>(undefined);
+
+const formatKeyLabel = (key: string): string => {
+  switch (key) {
+    case "arrowup":
+      return "↑";
+    case "arrowdown":
+      return "↓";
+    case "arrowleft":
+      return "←";
+    case "arrowright":
+      return "→";
+    case "esc":
+      return "Esc";
+    case "enter":
+      return "Enter";
+    case "space":
+      return "Space";
+    case "backspace":
+      return "Backspace";
+    case "delete":
+      return "Delete";
+    case "tab":
+      return "Tab";
+    case "home":
+      return "Home";
+    case "end":
+      return "End";
+    case "pageup":
+      return "Page Up";
+    case "pagedown":
+      return "Page Down";
+    default:
+      if (key.length === 1) {
+        return key.toUpperCase();
+      }
+      return key
+        .replace(/[-_]/g, " ")
+        .replace(/\b\w/g, (segment) => segment.toUpperCase());
+  }
+};
+
+const macSymbols: Record<string, string> = {
+  meta: "⌘",
+  ctrl: "⌃",
+  alt: "⌥",
+  shift: "⇧",
+};
+
+const pcLabels: Record<string, string> = {
+  meta: "Win",
+  ctrl: "Ctrl",
+  alt: "Alt",
+  shift: "Shift",
+};
+
+let idCounter = 0;
+
+const createId = () => {
+  idCounter += 1;
+  return `shortcut-${idCounter}`;
+};
+
+const ensureArray = <T,>(value: T | T[] | undefined): T[] => {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+};
+
+export const ShortcutsProvider = ({ children }: PropsWithChildren) => {
+  const [entries, setEntries] = useState<Map<string, RegisteredShortcut>>(() => new Map());
+  const entriesRef = useRef(entries);
+  const isMac = useMemo(() => isMacPlatform(), []);
+  const paletteRef = useRef<CommandPaletteApi | null>(null);
+
+  useEffect(() => {
+    entriesRef.current = entries;
+  }, [entries]);
+
+  const formatShortcut = useCallback(
+    (combo: string | string[]): string => {
+      const combos = ensureArray(combo)
+        .flatMap((value) => normalizeCombo(value))
+        .filter(Boolean);
+      if (combos.length === 0) return "";
+      const preferred =
+        combos.find((value) => (isMac ? value.includes("meta") : value.includes("ctrl"))) ??
+        combos[0];
+      const parts = preferred.split("+");
+      const key = parts.pop() ?? "";
+      const formattedModifiers = parts.map((modifier) =>
+        isMac ? macSymbols[modifier] ?? modifier.toUpperCase() : pcLabels[modifier] ?? modifier.toUpperCase(),
+      );
+      const keyLabel = formatKeyLabel(key);
+      const joiner = isMac ? " " : " + ";
+      return [...formattedModifiers, keyLabel].join(joiner).trim();
+    },
+    [isMac],
+  );
+
+  const registerShortcut = useCallback(
+    (config: ShortcutConfig) => {
+      const id = config.id ?? createId();
+      const combos = ensureArray(config.combo).flatMap((value) => normalizeCombo(value));
+      const displayCombo = combos.length > 0 ? formatShortcut(combos) : null;
+      const entry: RegisteredShortcut = {
+        ...config,
+        id,
+        combos,
+        displayCombo,
+        hidden: Boolean(config.hidden),
+      };
+      setEntries((prev) => {
+        const next = new Map(prev);
+        next.set(id, entry);
+        return next;
+      });
+      return () => {
+        setEntries((prev) => {
+          const next = new Map(prev);
+          next.delete(id);
+          return next;
+        });
+      };
+    },
+    [formatShortcut],
+  );
+
+  const openPalette = useCallback(() => {
+    paletteRef.current?.open();
+  }, []);
+
+  const closePalette = useCallback(() => {
+    paletteRef.current?.close();
+  }, []);
+
+  const togglePalette = useCallback(() => {
+    paletteRef.current?.toggle();
+  }, []);
+
+  const setPaletteApi = useCallback((api: CommandPaletteApi | null) => {
+    paletteRef.current = api;
+  }, []);
+
+  useEffect(() => {
+    return registerShortcut({
+      id: "mosaic.command-palette",
+      title: "Toggle command palette",
+      combo: "mod+k",
+      run: () => {
+        togglePalette();
+      },
+      hidden: true,
+      preventDefault: true,
+    });
+  }, [registerShortcut, togglePalette]);
+
+  useEffect(() => {
+    if (!isBrowser) return;
+    const handler = (event: KeyboardEvent) => {
+      const combo = eventToCombo(event);
+      if (!combo) return;
+      const target = event.target as HTMLElement | null;
+      entriesRef.current.forEach((entry) => {
+        if (!entry.combos.includes(combo)) return;
+        if (!entry.allowInInput && isEditableElement(target)) return;
+        if (entry.preventDefault !== false) {
+          event.preventDefault();
+        }
+        entry.run(event);
+      });
+    };
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+    };
+  }, []);
+
+  const shortcuts = useMemo(() => Array.from(entries.values()), [entries]);
+
+  const value = useMemo<ShortcutsContextValue>(
+    () => ({
+      registerShortcut,
+      shortcuts,
+      formatShortcut,
+      isMac,
+      openPalette,
+      closePalette,
+      togglePalette,
+      setPaletteApi,
+    }),
+    [registerShortcut, shortcuts, formatShortcut, isMac, openPalette, closePalette, togglePalette, setPaletteApi],
+  );
+
+  return <ShortcutsContext.Provider value={value}>{children}</ShortcutsContext.Provider>;
+};
+
+export const useShortcuts = () => {
+  const context = useContext(ShortcutsContext);
+  if (!context) {
+    throw new Error("useShortcuts must be used within a ShortcutsProvider");
+  }
+  return context;
+};
+
+export const useShortcut = (config: ShortcutConfig, deps: unknown[] = []) => {
+  const { registerShortcut } = useShortcuts();
+  useEffect(() => {
+    return registerShortcut(config);
+  }, [registerShortcut, ...deps]);
+};
+
+export const useCommand: typeof useShortcut = (config, deps) => {
+  useShortcut(config, deps);
+};
+
+export type { ShortcutConfig as CommandConfig };

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,0 +1,305 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type PropsWithChildren,
+} from "react";
+import { useIsomorphicLayoutEffect } from "../utils/use-isomorphic-layout-effect";
+import {
+  type Accent,
+  type Appearance,
+  type ColorVisionMode,
+  type PartialThemeOptions,
+  type ThemeContextValue,
+  type ThemeOptions,
+  type ThemeState,
+  type ThemeTokenName,
+} from "./types";
+import {
+  createThemeTokens,
+  tokenToVar,
+  tokensToCssVariables,
+  toCssText,
+} from "./color";
+import { baseStyles } from "./baseStyles";
+
+const defaultOptions: ThemeOptions = {
+  appearance: "light",
+  accent: "indigo",
+  colorVision: "normal",
+  highContrast: false,
+  reducedMotion: false,
+};
+
+type StoredTheme = Pick<
+  ThemeOptions,
+  "appearance" | "accent" | "colorVision" | "highContrast" | "reducedMotion"
+>;
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const canUseDOM = typeof window !== "undefined" && typeof document !== "undefined";
+
+const readStoredTheme = (storageKey?: string): Partial<StoredTheme> => {
+  if (!storageKey || !canUseDOM) return {};
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as StoredTheme;
+    return parsed;
+  } catch (error) {
+    console.warn("mosaic: failed to parse stored theme", error);
+    return {};
+  }
+};
+
+const storeTheme = (storageKey: string | undefined, options: StoredTheme) => {
+  if (!storageKey || !canUseDOM) return;
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(options));
+  } catch (error) {
+    console.warn("mosaic: failed to persist theme", error);
+  }
+};
+
+const getSystemPreferences = (): PartialThemeOptions => {
+  if (!canUseDOM) return {};
+  const preferences: PartialThemeOptions = {};
+  try {
+    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      preferences.appearance = "dark";
+    }
+  } catch {
+    /* noop */
+  }
+  try {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      preferences.reducedMotion = true;
+    }
+  } catch {
+    /* noop */
+  }
+  try {
+    if (window.matchMedia("(prefers-contrast: more)").matches) {
+      preferences.highContrast = true;
+    }
+  } catch {
+    /* noop */
+  }
+  return preferences;
+};
+
+const mergeOptions = (
+  base: ThemeOptions,
+  overrides: PartialThemeOptions,
+): ThemeOptions => ({
+  ...base,
+  ...overrides,
+});
+
+const createState = (options: ThemeOptions): ThemeState => ({
+  ...options,
+  tokens: createThemeTokens(options),
+});
+
+export interface ThemeProviderProps extends PropsWithChildren {
+  initialTheme?: PartialThemeOptions;
+  syncWithSystem?: boolean;
+  storageKey?: string;
+}
+
+export const ThemeProvider = ({
+  children,
+  initialTheme,
+  syncWithSystem = true,
+  storageKey,
+}: ThemeProviderProps) => {
+  const [options, setOptions] = useState<ThemeOptions>(() => {
+    const stored = readStoredTheme(storageKey);
+    const system = getSystemPreferences();
+    return mergeOptions(defaultOptions, {
+      ...system,
+      ...initialTheme,
+      ...stored,
+    });
+  });
+
+  const state = useMemo(() => createState(options), [options]);
+
+  const cssVariables = useMemo(() => {
+    const entries = tokensToCssVariables(state.tokens);
+    const style: Record<string, string> = {};
+    Object.entries(entries).forEach(([key, value]) => {
+      style[key] = value;
+    });
+    style.colorScheme = state.appearance;
+    return style as CSSProperties;
+  }, [state.appearance, state.tokens]);
+
+  const cssText = useMemo(() => toCssText(state, state.tokens), [state.appearance, state.tokens]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!canUseDOM) return;
+    const root = document.documentElement;
+    root.setAttribute("data-mosaic-theme", state.appearance);
+    root.setAttribute("data-mosaic-color-vision", state.colorVision);
+    root.setAttribute("data-mosaic-high-contrast", state.highContrast ? "true" : "false");
+    root.setAttribute("data-mosaic-reduced-motion", state.reducedMotion ? "true" : "false");
+
+    const entries = tokensToCssVariables(state.tokens);
+    Object.entries(entries).forEach(([key, value]) => {
+      root.style.setProperty(key, value);
+    });
+    root.style.setProperty("color-scheme", state.appearance);
+
+    return () => {
+      root.removeAttribute("data-mosaic-theme");
+      root.removeAttribute("data-mosaic-color-vision");
+      root.removeAttribute("data-mosaic-high-contrast");
+      root.removeAttribute("data-mosaic-reduced-motion");
+    };
+  }, [state]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!storageKey) return;
+    storeTheme(storageKey, {
+      appearance: state.appearance,
+      accent: state.accent,
+      colorVision: state.colorVision,
+      highContrast: state.highContrast,
+      reducedMotion: state.reducedMotion,
+    });
+  }, [state, storageKey]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!syncWithSystem || !canUseDOM) return;
+    const colorScheme = window.matchMedia("(prefers-color-scheme: dark)");
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let highContrast: MediaQueryList | undefined;
+    try {
+      highContrast = window.matchMedia("(prefers-contrast: more)");
+    } catch {
+      highContrast = undefined;
+    }
+
+    const handleAppearance = () => {
+      setOptions((prev) => ({
+        ...prev,
+        appearance: colorScheme.matches ? "dark" : "light",
+      }));
+    };
+    const handleMotion = () => {
+      setOptions((prev) => ({
+        ...prev,
+        reducedMotion: reducedMotion.matches,
+      }));
+    };
+    const handleContrast = () => {
+      if (!highContrast) return;
+      setOptions((prev) => ({
+        ...prev,
+        highContrast: highContrast!.matches,
+      }));
+    };
+
+    colorScheme.addEventListener("change", handleAppearance);
+    reducedMotion.addEventListener("change", handleMotion);
+    if (highContrast) {
+      highContrast.addEventListener("change", handleContrast);
+    }
+
+    return () => {
+      colorScheme.removeEventListener("change", handleAppearance);
+      reducedMotion.removeEventListener("change", handleMotion);
+      if (highContrast) {
+        highContrast.removeEventListener("change", handleContrast);
+      }
+    };
+  }, [syncWithSystem]);
+
+  const setAppearance = useCallback((appearance: Appearance) => {
+    setOptions((prev) => ({ ...prev, appearance }));
+  }, []);
+
+  const toggleAppearance = useCallback(() => {
+    setOptions((prev) => ({
+      ...prev,
+      appearance: prev.appearance === "light" ? "dark" : "light",
+    }));
+  }, []);
+
+  const setAccent = useCallback((accent: Accent) => {
+    setOptions((prev) => ({ ...prev, accent }));
+  }, []);
+
+  const setColorVision = useCallback((mode: ColorVisionMode) => {
+    setOptions((prev) => ({ ...prev, colorVision: mode }));
+  }, []);
+
+  const setHighContrast = useCallback((value: boolean) => {
+    setOptions((prev) => ({ ...prev, highContrast: value }));
+  }, []);
+
+  const toggleHighContrast = useCallback(() => {
+    setOptions((prev) => ({ ...prev, highContrast: !prev.highContrast }));
+  }, []);
+
+  const setReducedMotion = useCallback((value: boolean) => {
+    setOptions((prev) => ({ ...prev, reducedMotion: value }));
+  }, []);
+
+  const toggleReducedMotion = useCallback(() => {
+    setOptions((prev) => ({ ...prev, reducedMotion: !prev.reducedMotion }));
+  }, []);
+
+  const context = useMemo<ThemeContextValue>(() => ({
+    ...state,
+    setAppearance,
+    toggleAppearance,
+    setAccent,
+    setColorVision,
+    setHighContrast,
+    toggleHighContrast,
+    setReducedMotion,
+    toggleReducedMotion,
+    getVar: (token: ThemeTokenName) => state.tokens[token],
+    cssVariables,
+  }), [
+    state,
+    setAppearance,
+    toggleAppearance,
+    setAccent,
+    setColorVision,
+    setHighContrast,
+    toggleHighContrast,
+    setReducedMotion,
+    toggleReducedMotion,
+    cssVariables,
+  ]);
+
+  return (
+    <ThemeContext.Provider value={context}>
+      <style data-mosaic-base="" dangerouslySetInnerHTML={{ __html: baseStyles }} />
+      <style data-mosaic-theme="" dangerouslySetInnerHTML={{ __html: cssText }} />
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+};
+
+export const useThemeValue = (token: ThemeTokenName) => {
+  const { getVar } = useTheme();
+  return getVar(token);
+};
+
+export const getCssVar = (token: ThemeTokenName) => tokenToVar(token);

--- a/src/theme/baseStyles.ts
+++ b/src/theme/baseStyles.ts
@@ -1,0 +1,310 @@
+export const baseStyles = `
+:root {
+  --mosaic-focus-ring: 0 0 0 1px var(--mosaic-color-inverted), 0 0 0 4px var(--mosaic-color-ring);
+}
+
+.mosaic-button {
+  appearance: none;
+  border: var(--mosaic-border-width) solid var(--mosaic-button-border, transparent);
+  border-radius: var(--mosaic-radius-md);
+  background-color: var(--mosaic-button-bg, transparent);
+  color: var(--mosaic-button-fg, var(--mosaic-color-text));
+  font-family: var(--mosaic-font-family-base);
+  font-weight: 600;
+  font-size: var(--mosaic-button-font-size, var(--mosaic-text-size-md));
+  line-height: var(--mosaic-line-height-tight);
+  padding-block: var(--mosaic-button-padding-y, var(--mosaic-spacing-sm));
+  padding-inline: var(--mosaic-button-padding-x, var(--mosaic-spacing-md));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--mosaic-spacing-xs);
+  cursor: pointer;
+  text-decoration: none;
+  position: relative;
+  transition: background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    border-color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    box-shadow var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    transform var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+  min-height: calc(2.5rem + var(--mosaic-button-size-adjust, 0));
+}
+
+.mosaic-button[data-full-width="true"] {
+  width: 100%;
+}
+
+.mosaic-button:focus-visible {
+  outline: none;
+  box-shadow: var(--mosaic-focus-ring);
+}
+
+.mosaic-button[data-variant="solid"]:hover:not(:disabled),
+.mosaic-button[data-variant="solid"]:focus-visible:not(:disabled) {
+  background-color: var(--mosaic-button-bg-hover, var(--mosaic-button-bg));
+}
+
+.mosaic-button[data-variant="solid"]:active:not(:disabled) {
+  background-color: var(--mosaic-button-bg-active, var(--mosaic-button-bg));
+  transform: translateY(1px);
+}
+
+.mosaic-button[data-variant="soft"] {
+  border-color: var(--mosaic-button-border, transparent);
+}
+
+.mosaic-button[data-variant="soft"]:hover:not(:disabled),
+.mosaic-button[data-variant="soft"]:focus-visible:not(:disabled) {
+  background-color: var(--mosaic-button-bg-hover, var(--mosaic-button-bg));
+  border-color: var(--mosaic-button-border-hover, var(--mosaic-button-border));
+}
+
+.mosaic-button[data-variant="soft"]:active:not(:disabled) {
+  background-color: var(--mosaic-button-bg-active, var(--mosaic-button-bg));
+}
+
+.mosaic-button[data-variant="outline"] {
+  background-color: transparent;
+  border-color: var(--mosaic-button-border, var(--mosaic-color-border));
+}
+
+.mosaic-button[data-variant="outline"]:hover:not(:disabled),
+.mosaic-button[data-variant="outline"]:focus-visible:not(:disabled) {
+  background-color: var(--mosaic-button-bg-hover, var(--mosaic-color-surface-hover));
+  border-color: var(--mosaic-button-border-hover, var(--mosaic-button-border));
+}
+
+.mosaic-button[data-variant="outline"]:active:not(:disabled) {
+  background-color: var(--mosaic-button-bg-active, var(--mosaic-color-surface-active));
+}
+
+.mosaic-button[data-variant="ghost"] {
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.mosaic-button[data-variant="ghost"]:hover:not(:disabled),
+.mosaic-button[data-variant="ghost"]:focus-visible:not(:disabled) {
+  background-color: var(--mosaic-button-bg-hover, var(--mosaic-color-surface-hover));
+}
+
+.mosaic-button[data-variant="ghost"]:active:not(:disabled) {
+  background-color: var(--mosaic-button-bg-active, var(--mosaic-color-surface-active));
+}
+
+.mosaic-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.mosaic-button[data-loading="true"] {
+  cursor: progress;
+}
+
+.mosaic-button__label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mosaic-button__spinner {
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  border-top-color: currentColor;
+  border-right-color: currentColor;
+  animation: mosaic-spin 0.8s linear infinite;
+}
+
+[data-mosaic-reduced-motion="true"] .mosaic-button__spinner {
+  animation: none;
+  border-top-color: currentColor;
+  border-right-color: currentColor;
+}
+
+@keyframes mosaic-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.mosaic-card {
+  background-color: var(--mosaic-card-bg, var(--mosaic-color-surface));
+  color: var(--mosaic-card-fg, var(--mosaic-color-text));
+  border: var(--mosaic-border-width) solid var(--mosaic-card-border, var(--mosaic-color-border));
+  border-radius: var(--mosaic-radius-lg);
+  padding: var(--mosaic-card-padding, var(--mosaic-spacing-lg));
+  box-shadow: var(--mosaic-card-shadow, var(--mosaic-shadow-sm));
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-md);
+  transition: box-shadow var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    transform var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-card[data-hoverable="true"]:hover {
+  box-shadow: var(--mosaic-card-shadow-hover, var(--mosaic-shadow-md));
+  transform: translateY(-1px);
+}
+
+.mosaic-card[data-elevated="true"] {
+  box-shadow: var(--mosaic-shadow-md);
+}
+
+.mosaic-card[data-tone="primary"] {
+  --mosaic-card-bg: var(--mosaic-color-primary-soft);
+  --mosaic-card-border: var(--mosaic-color-primary-border);
+}
+
+.mosaic-text {
+  margin: 0;
+  color: var(--mosaic-text-color, inherit);
+  font-family: var(--mosaic-font-family-base);
+}
+
+.mosaic-text[data-variant="muted"] {
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-text[data-variant="subtle"] {
+  color: var(--mosaic-color-text-subtle);
+}
+
+.mosaic-text[data-variant="code"] {
+  font-family: var(--mosaic-font-family-mono);
+  font-size: var(--mosaic-text-size-sm);
+  background: var(--mosaic-color-surface-hover);
+  padding: 0.125rem 0.25rem;
+  border-radius: var(--mosaic-radius-sm);
+}
+
+.mosaic-text[data-variant="headline"] {
+  font-size: var(--mosaic-text-size-2xl);
+  font-weight: 700;
+  line-height: var(--mosaic-line-height-tight);
+}
+
+.mosaic-text[data-variant="title"] {
+  font-size: var(--mosaic-text-size-xl);
+  font-weight: 600;
+  line-height: var(--mosaic-line-height-tight);
+}
+
+.mosaic-text[data-variant="label"] {
+  font-size: var(--mosaic-text-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--mosaic-color-text-subtle);
+}
+
+.mosaic-text[data-variant="caption"] {
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-stack {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: var(--mosaic-stack-gap, var(--mosaic-spacing-md));
+  align-items: var(--mosaic-stack-align, stretch);
+  justify-content: var(--mosaic-stack-justify, flex-start);
+}
+
+.mosaic-stack[data-direction="column"] {
+  flex-direction: column;
+}
+
+.mosaic-stack[data-direction="row"] {
+  flex-direction: row;
+}
+
+.mosaic-input {
+  width: 100%;
+  font: inherit;
+  padding-block: var(--mosaic-input-padding-y, var(--mosaic-spacing-sm));
+  padding-inline: var(--mosaic-input-padding-x, var(--mosaic-spacing-md));
+  border-radius: var(--mosaic-radius-md);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  background-color: var(--mosaic-color-surface);
+  color: var(--mosaic-color-text);
+  font-size: var(--mosaic-input-font-size, var(--mosaic-text-size-md));
+  line-height: var(--mosaic-line-height-normal);
+  transition: border-color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    box-shadow var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-input::placeholder {
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-input:focus-visible {
+  outline: none;
+  border-color: var(--mosaic-color-ring);
+  box-shadow: var(--mosaic-focus-ring);
+}
+
+.mosaic-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.mosaic-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-xs);
+}
+
+.mosaic-field__label {
+  font-size: var(--mosaic-text-size-sm);
+  font-weight: 600;
+  color: var(--mosaic-color-text);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.mosaic-field__required {
+  color: var(--mosaic-color-danger);
+}
+
+.mosaic-field__control {
+  display: flex;
+  flex-direction: column;
+}
+
+.mosaic-field__description {
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-subtle);
+}
+
+.mosaic-field__hint {
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-field__error {
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-danger);
+}
+
+.mosaic-field[data-invalid="true"] .mosaic-input {
+  border-color: var(--mosaic-color-danger);
+  box-shadow: 0 0 0 1px var(--mosaic-color-danger);
+}
+
+.mosaic-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+`;

--- a/src/theme/baseStyles.ts
+++ b/src/theme/baseStyles.ts
@@ -307,4 +307,862 @@ export const baseStyles = `
   white-space: nowrap;
   border: 0;
 }
+
+.mosaic-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--mosaic-spacing-lg);
+  background-color: rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(8px);
+}
+
+[data-mosaic-theme="dark"] .mosaic-overlay {
+  background-color: rgba(15, 23, 42, 0.6);
+}
+
+[data-mosaic-reduced-motion="true"] .mosaic-overlay {
+  backdrop-filter: none;
+}
+
+.mosaic-overlay[data-variant="sheet"] {
+  align-items: stretch;
+  padding: 0;
+}
+
+.mosaic-overlay[data-variant="sheet"][data-side="left"] {
+  justify-content: flex-start;
+}
+
+.mosaic-overlay[data-variant="sheet"][data-side="right"] {
+  justify-content: flex-end;
+}
+
+.mosaic-overlay[data-variant="sheet"][data-side="bottom"] {
+  justify-content: center;
+  align-items: flex-end;
+}
+
+.mosaic-dialog {
+  background-color: var(--mosaic-color-surface);
+  color: var(--mosaic-color-text);
+  border-radius: var(--mosaic-radius-lg);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  box-shadow: var(--mosaic-shadow-lg);
+  min-width: min(32rem, calc(100vw - 4rem));
+  max-width: calc(100vw - 4rem);
+  max-height: calc(100vh - 4rem);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.mosaic-dialog[data-size="sm"] {
+  min-width: min(24rem, calc(100vw - 4rem));
+}
+
+.mosaic-dialog[data-size="lg"] {
+  min-width: min(40rem, calc(100vw - 4rem));
+}
+
+.mosaic-dialog[data-size="xl"] {
+  min-width: min(48rem, calc(100vw - 4rem));
+}
+
+.mosaic-dialog[data-size="full"] {
+  min-width: calc(100vw - 2rem);
+}
+
+.mosaic-dialog[data-variant="sheet"] {
+  border-radius: 0;
+  max-width: min(28rem, 100vw);
+  min-width: min(24rem, 100vw);
+  height: 100%;
+  max-height: none;
+}
+
+.mosaic-dialog[data-variant="sheet"][data-side="left"] {
+  border-right: var(--mosaic-border-width) solid var(--mosaic-color-border);
+}
+
+.mosaic-dialog[data-variant="sheet"][data-side="right"] {
+  border-left: var(--mosaic-border-width) solid var(--mosaic-color-border);
+}
+
+.mosaic-dialog[data-variant="sheet"][data-side="bottom"] {
+  width: 100%;
+  max-width: none;
+  height: min(32rem, 100%);
+  border-top: var(--mosaic-border-width) solid var(--mosaic-color-border);
+}
+
+.mosaic-dialog__close {
+  position: absolute;
+  top: var(--mosaic-spacing-sm);
+  right: var(--mosaic-spacing-sm);
+  border: none;
+  background: transparent;
+  color: var(--mosaic-color-text-muted);
+  font-size: var(--mosaic-text-size-xl);
+  line-height: 1;
+  padding: var(--mosaic-spacing-xs);
+  border-radius: var(--mosaic-radius-sm);
+  cursor: pointer;
+}
+
+.mosaic-dialog__close:hover,
+.mosaic-dialog__close:focus-visible {
+  background-color: var(--mosaic-color-surface-hover);
+  color: var(--mosaic-color-text);
+}
+
+.mosaic-dialog__header {
+  padding: var(--mosaic-spacing-lg);
+  border-bottom: var(--mosaic-border-width) solid var(--mosaic-color-border);
+}
+
+.mosaic-dialog__title {
+  font-size: var(--mosaic-text-size-xl);
+  font-weight: 600;
+  margin: 0;
+}
+
+.mosaic-dialog__description {
+  margin: var(--mosaic-spacing-xs) 0 0;
+  color: var(--mosaic-color-text-subtle);
+  font-size: var(--mosaic-text-size-sm);
+}
+
+.mosaic-dialog__body {
+  padding: var(--mosaic-spacing-lg);
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.mosaic-dialog__footer {
+  padding: var(--mosaic-spacing-md) var(--mosaic-spacing-lg);
+  border-top: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--mosaic-spacing-sm);
+}
+
+.mosaic-dialog[data-variant="command"] {
+  max-width: min(40rem, calc(100vw - 3rem));
+}
+
+.mosaic-dialog[data-variant="command"] .mosaic-dialog__body {
+  padding: 0;
+}
+
+.mosaic-command {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.mosaic-command__search {
+  padding: var(--mosaic-spacing-lg);
+  border-bottom: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-xs);
+}
+
+.mosaic-command__label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-subtle);
+}
+
+.mosaic-command__shortcut {
+  background-color: var(--mosaic-color-surface-hover);
+  border-radius: var(--mosaic-radius-sm);
+  padding: 0.125rem 0.5rem;
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-command__input {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: var(--mosaic-color-surface-hover);
+  color: var(--mosaic-color-text);
+  padding: var(--mosaic-spacing-sm);
+  border-radius: var(--mosaic-radius-md);
+  font-size: var(--mosaic-text-size-md);
+}
+
+.mosaic-command__results {
+  max-height: 22rem;
+  overflow-y: auto;
+}
+
+.mosaic-command__list {
+  display: flex;
+  flex-direction: column;
+  padding: var(--mosaic-spacing-xs) 0;
+}
+
+.mosaic-command__section {
+  padding: var(--mosaic-spacing-xs) var(--mosaic-spacing-md);
+}
+
+.mosaic-command__section-label {
+  font-size: var(--mosaic-text-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--mosaic-color-text-muted);
+  margin-bottom: var(--mosaic-spacing-xs);
+}
+
+.mosaic-command__option {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--mosaic-spacing-sm) var(--mosaic-spacing-md);
+  border-radius: var(--mosaic-radius-md);
+  cursor: pointer;
+  color: var(--mosaic-color-text);
+}
+
+.mosaic-command__option:hover,
+.mosaic-command__option--active {
+  background-color: var(--mosaic-color-surface-hover);
+}
+
+.mosaic-command__option-title {
+  font-weight: 500;
+}
+
+.mosaic-command__option-description {
+  display: block;
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-command__option-shortcut {
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-command__empty {
+  padding: var(--mosaic-spacing-lg);
+  text-align: center;
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-tooltip {
+  position: fixed;
+  z-index: 1100;
+  background-color: var(--mosaic-color-text);
+  color: var(--mosaic-color-inverted);
+  padding: 0.35rem 0.55rem;
+  border-radius: var(--mosaic-radius-sm);
+  font-size: var(--mosaic-text-size-sm);
+  box-shadow: var(--mosaic-shadow-sm);
+  pointer-events: none;
+  display: inline-flex;
+  gap: var(--mosaic-spacing-xs);
+  align-items: center;
+}
+
+.mosaic-tooltip[data-side="top"]::after,
+.mosaic-tooltip[data-side="bottom"]::after,
+.mosaic-tooltip[data-side="left"]::after,
+.mosaic-tooltip[data-side="right"]::after {
+  content: "";
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+
+.mosaic-tooltip[data-side="top"]::after {
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px 6px 0 6px;
+  border-color: var(--mosaic-color-text) transparent transparent transparent;
+}
+
+.mosaic-tooltip[data-side="bottom"]::after {
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 0 6px 6px 6px;
+  border-color: transparent transparent var(--mosaic-color-text) transparent;
+}
+
+.mosaic-tooltip[data-side="left"]::after {
+  right: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-width: 6px 0 6px 6px;
+  border-color: transparent transparent transparent var(--mosaic-color-text);
+}
+
+.mosaic-tooltip[data-side="right"]::after {
+  left: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-width: 6px 6px 6px 0;
+  border-color: transparent var(--mosaic-color-text) transparent transparent;
+}
+
+.mosaic-tooltip__shortcut {
+  font-weight: 600;
+}
+
+.mosaic-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mosaic-spacing-sm);
+  cursor: pointer;
+}
+
+.mosaic-switch__input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mosaic-switch__track {
+  width: 2.75rem;
+  height: 1.5rem;
+  background-color: var(--mosaic-color-surface-hover);
+  border-radius: 999px;
+  position: relative;
+  transition: background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-switch__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1.1rem;
+  height: 1.1rem;
+  background-color: var(--mosaic-color-inverted);
+  border-radius: 50%;
+  box-shadow: var(--mosaic-shadow-sm);
+  transition: transform var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-switch__input:checked + .mosaic-switch__track {
+  background-color: var(--mosaic-color-primary);
+}
+
+.mosaic-switch__input:checked + .mosaic-switch__track .mosaic-switch__thumb {
+  transform: translateX(1.25rem);
+}
+
+.mosaic-switch__input:focus-visible + .mosaic-switch__track {
+  box-shadow: var(--mosaic-focus-ring);
+}
+
+.mosaic-switch__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.mosaic-switch__label {
+  font-weight: 500;
+}
+
+.mosaic-switch__description,
+.mosaic-checkbox__description {
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-checkbox {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: var(--mosaic-spacing-sm);
+  cursor: pointer;
+}
+
+.mosaic-checkbox__control {
+  position: relative;
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.mosaic-checkbox__input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+}
+
+.mosaic-checkbox__indicator {
+  width: 100%;
+  height: 100%;
+  border-radius: var(--mosaic-radius-sm);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  background: var(--mosaic-color-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    border-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-checkbox__input:checked + .mosaic-checkbox__indicator {
+  background-color: var(--mosaic-color-primary);
+  border-color: var(--mosaic-color-primary);
+  color: var(--mosaic-color-primary-contrast);
+}
+
+.mosaic-checkbox__input:checked + .mosaic-checkbox__indicator::after {
+  content: "✔";
+  font-size: 0.75rem;
+}
+
+.mosaic-checkbox__input:indeterminate + .mosaic-checkbox__indicator::after {
+  content: "";
+  width: 0.6rem;
+  height: 0.15rem;
+  background-color: currentColor;
+  border-radius: var(--mosaic-radius-sm);
+}
+
+.mosaic-checkbox__input:focus-visible + .mosaic-checkbox__indicator {
+  box-shadow: var(--mosaic-focus-ring);
+}
+
+.mosaic-checkbox__label {
+  font-weight: 500;
+}
+
+.mosaic-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  border: 1px solid var(--mosaic-badge-border, transparent);
+  background-color: var(--mosaic-badge-bg, transparent);
+  color: var(--mosaic-badge-fg, var(--mosaic-color-text));
+  font-size: var(--mosaic-text-size-sm);
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+}
+
+.mosaic-badge__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mosaic-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--mosaic-color-surface-hover);
+  color: var(--mosaic-color-text);
+  font-weight: 600;
+  position: relative;
+  overflow: hidden;
+}
+
+.mosaic-avatar[data-shape="square"] {
+  border-radius: var(--mosaic-radius-md);
+}
+
+.mosaic-avatar[data-size="sm"] {
+  width: 2rem;
+  height: 2rem;
+  font-size: var(--mosaic-text-size-sm);
+}
+
+.mosaic-avatar[data-size="md"] {
+  width: 2.5rem;
+  height: 2.5rem;
+  font-size: var(--mosaic-text-size-md);
+}
+
+.mosaic-avatar[data-size="lg"] {
+  width: 3.5rem;
+  height: 3.5rem;
+  font-size: var(--mosaic-text-size-lg);
+}
+
+.mosaic-avatar__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.mosaic-avatar__fallback {
+  letter-spacing: 0.05em;
+}
+
+.mosaic-progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-xs);
+}
+
+.mosaic-progress__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-progress__track {
+  width: 100%;
+  height: 0.5rem;
+  border-radius: 999px;
+  background-color: var(--mosaic-color-surface-hover);
+  overflow: hidden;
+}
+
+.mosaic-progress__indicator {
+  height: 100%;
+  background: linear-gradient(90deg, var(--mosaic-color-primary) 0%, var(--mosaic-color-primary-border) 100%);
+  transition: width var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-progress[data-indeterminate="true"] .mosaic-progress__indicator {
+  width: 40%;
+  animation: mosaic-progress-indeterminate 1.2s linear infinite;
+}
+
+@keyframes mosaic-progress-indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(20%);
+  }
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+.mosaic-date-picker {
+  position: relative;
+}
+
+.mosaic-combobox {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-xs);
+}
+
+.mosaic-combobox__control {
+  position: relative;
+}
+
+.mosaic-combobox__input {
+  padding-right: 2.5rem;
+}
+
+.mosaic-combobox__clear {
+  position: absolute;
+  right: 0.4rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: transparent;
+  color: var(--mosaic-color-text-muted);
+  font-size: var(--mosaic-text-size-lg);
+  cursor: pointer;
+}
+
+.mosaic-combobox__list {
+  position: absolute;
+  z-index: 900;
+  margin-top: 0.25rem;
+  width: 100%;
+  max-height: 16rem;
+  overflow-y: auto;
+  background: var(--mosaic-color-surface);
+  border-radius: var(--mosaic-radius-md);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  box-shadow: var(--mosaic-shadow-md);
+}
+
+.mosaic-combobox__option {
+  padding: var(--mosaic-spacing-sm) var(--mosaic-spacing-md);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.mosaic-combobox__option--active,
+.mosaic-combobox__option:hover {
+  background-color: var(--mosaic-color-surface-hover);
+}
+
+.mosaic-combobox__option--selected {
+  font-weight: 600;
+}
+
+.mosaic-combobox__option--disabled {
+  color: var(--mosaic-color-text-muted);
+  cursor: not-allowed;
+}
+
+.mosaic-combobox__empty {
+  padding: var(--mosaic-spacing-md);
+  text-align: center;
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-context-menu {
+  position: fixed;
+  z-index: 950;
+  min-width: 12rem;
+  background: var(--mosaic-color-surface);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  border-radius: var(--mosaic-radius-md);
+  box-shadow: var(--mosaic-shadow-lg);
+  padding: var(--mosaic-spacing-xs);
+  display: flex;
+  flex-direction: column;
+}
+
+.mosaic-context-menu__item {
+  width: 100%;
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--mosaic-spacing-sm);
+  padding: var(--mosaic-spacing-sm) var(--mosaic-spacing-md);
+  border-radius: var(--mosaic-radius-sm);
+  cursor: pointer;
+  color: var(--mosaic-color-text);
+}
+
+.mosaic-context-menu__item--active,
+.mosaic-context-menu__item:not([disabled]):hover {
+  background-color: var(--mosaic-color-surface-hover);
+}
+
+.mosaic-context-menu__item[disabled],
+.mosaic-context-menu__item[data-disabled="true"] {
+  color: var(--mosaic-color-text-muted);
+  cursor: not-allowed;
+}
+
+.mosaic-context-menu__separator {
+  height: 1px;
+  margin: var(--mosaic-spacing-xs) 0;
+  background-color: var(--mosaic-color-border);
+}
+
+.mosaic-context-menu__shortcut {
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-toast-viewport {
+  position: fixed;
+  z-index: 1200;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-sm);
+  padding: var(--mosaic-spacing-sm);
+  width: min(24rem, 100vw);
+}
+
+.mosaic-toast-viewport[data-placement="top-left"] {
+  top: 0;
+  left: 0;
+}
+
+.mosaic-toast-viewport[data-placement="top-right"] {
+  top: 0;
+  right: 0;
+}
+
+.mosaic-toast-viewport[data-placement="bottom-left"] {
+  bottom: 0;
+  left: 0;
+}
+
+.mosaic-toast-viewport[data-placement="bottom-right"] {
+  bottom: 0;
+  right: 0;
+}
+
+.mosaic-toast {
+  background-color: var(--mosaic-color-surface);
+  color: var(--mosaic-color-text);
+  border-radius: var(--mosaic-radius-md);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  box-shadow: var(--mosaic-shadow-md);
+  padding: var(--mosaic-spacing-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-sm);
+}
+
+.mosaic-toast--success {
+  border-color: var(--mosaic-color-success);
+}
+
+.mosaic-toast--warning {
+  border-color: var(--mosaic-color-warning);
+}
+
+.mosaic-toast--danger {
+  border-color: var(--mosaic-color-danger);
+}
+
+.mosaic-toast--primary {
+  border-color: var(--mosaic-color-primary);
+}
+
+.mosaic-toast__body {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--mosaic-spacing-sm);
+}
+
+.mosaic-toast__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.mosaic-toast__title {
+  font-weight: 600;
+}
+
+.mosaic-toast__description {
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-toast__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--mosaic-spacing-xs);
+}
+
+.mosaic-toast__action,
+.mosaic-toast__close {
+  border: none;
+  background: transparent;
+  color: var(--mosaic-color-text);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.mosaic-toast__action:hover,
+.mosaic-toast__close:hover,
+.mosaic-toast__action:focus-visible,
+.mosaic-toast__close:focus-visible {
+  color: var(--mosaic-color-primary);
+}
+
+.mosaic-pagination {
+  display: flex;
+  align-items: center;
+  gap: var(--mosaic-spacing-sm);
+}
+
+.mosaic-pagination__list {
+  display: flex;
+  gap: var(--mosaic-spacing-xs);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mosaic-pagination__ellipsis {
+  padding: 0 var(--mosaic-spacing-sm);
+  color: var(--mosaic-color-text-muted);
+  align-self: center;
+}
+
+.mosaic-table-container {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: var(--mosaic-radius-lg);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+}
+
+.mosaic-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background-color: var(--mosaic-color-surface);
+}
+
+.mosaic-table__caption {
+  text-align: left;
+  padding: var(--mosaic-spacing-md);
+  font-weight: 600;
+}
+
+.mosaic-table th,
+.mosaic-table td {
+  padding: var(--mosaic-spacing-sm) var(--mosaic-spacing-md);
+  border-bottom: var(--mosaic-border-width) solid var(--mosaic-color-border);
+}
+
+.mosaic-table__header {
+  text-align: left;
+  background-color: var(--mosaic-color-surface-hover);
+  font-size: var(--mosaic-text-size-sm);
+  color: var(--mosaic-color-text-subtle);
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.mosaic-table__header--center,
+.mosaic-table__cell--center {
+  text-align: center;
+}
+
+.mosaic-table__header--right,
+.mosaic-table__cell--right {
+  text-align: right;
+}
+
+.mosaic-table__sort {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--mosaic-spacing-xs);
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.mosaic-table__sort-indicator {
+  font-size: var(--mosaic-text-size-sm);
+}
+
+.mosaic-table__cell {
+  font-size: var(--mosaic-text-size-sm);
+}
+
+.mosaic-table__empty {
+  text-align: center;
+  padding: var(--mosaic-spacing-lg);
+  color: var(--mosaic-color-text-muted);
+}
 `;

--- a/src/theme/color.ts
+++ b/src/theme/color.ts
@@ -1,0 +1,321 @@
+import type { ThemeOptions, ThemeTokens, ThemeTokenName, Appearance, Accent, ColorVisionMode } from "./types";
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+const clamp = (value: number, min = 0, max = 255) => Math.min(Math.max(value, min), max);
+
+const hexToRgb = (hex: string): RGB => {
+  const normalized = hex.replace(/^#/, "");
+  const value = normalized.length === 3
+    ? normalized.split("").map((c) => parseInt(c + c, 16))
+    : [
+        parseInt(normalized.slice(0, 2), 16),
+        parseInt(normalized.slice(2, 4), 16),
+        parseInt(normalized.slice(4, 6), 16),
+      ];
+  const [r, g, b] = value;
+  return { r, g, b };
+};
+
+const rgbToHex = ({ r, g, b }: RGB): string => {
+  const toHex = (component: number) => {
+    const clamped = clamp(Math.round(component));
+    const hex = clamped.toString(16);
+    return hex.length === 1 ? `0${hex}` : hex;
+  };
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+};
+
+const mix = (foreground: string, background: string, weight: number): string => {
+  const fg = hexToRgb(foreground);
+  const bg = hexToRgb(background);
+  const w = clamp(weight, 0, 1);
+  const mixChannel = (from: number, to: number) => from * (1 - w) + to * w;
+  return rgbToHex({
+    r: mixChannel(fg.r, bg.r),
+    g: mixChannel(fg.g, bg.g),
+    b: mixChannel(fg.b, bg.b),
+  });
+};
+
+const relativeLuminance = ({ r, g, b }: RGB): number => {
+  const toLinear = (component: number) => {
+    const channel = component / 255;
+    return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+  };
+  const [lr, lg, lb] = [toLinear(r), toLinear(g), toLinear(b)];
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+};
+
+const contrastRatio = (color1: string, color2: string): number => {
+  const lum1 = relativeLuminance(hexToRgb(color1));
+  const lum2 = relativeLuminance(hexToRgb(color2));
+  const [lighter, darker] = lum1 > lum2 ? [lum1, lum2] : [lum2, lum1];
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+const ensureContrast = (foreground: string, background: string, target = 4.5): string => {
+  let current = foreground;
+  let ratio = contrastRatio(current, background);
+  if (ratio >= target) return current;
+
+  const bgLum = relativeLuminance(hexToRgb(background));
+  const direction = bgLum <= 0.5 ? "#ffffff" : "#000000";
+
+  let attempts = 0;
+  while (ratio < target && attempts < 12) {
+    current = mix(current, direction, 0.1);
+    ratio = contrastRatio(current, background);
+    attempts += 1;
+  }
+  return current;
+};
+
+const accentPalette: Record<Accent, string> = {
+  indigo: "#6366f1",
+  azure: "#2563eb",
+  violet: "#7c3aed",
+  emerald: "#059669",
+  amber: "#f59e0b",
+  rose: "#f43f5e",
+  neutral: "#6b7280",
+};
+
+const semanticDefaults = {
+  success: "#10b981",
+  warning: "#f59e0b",
+  danger: "#ef4444",
+  neutral: "#6b7280",
+};
+
+const colorVisionSemantics: Record<ColorVisionMode, Partial<typeof semanticDefaults> & { primary?: string }> = {
+  normal: {},
+  protanopia: {
+    primary: "#1f77b4",
+    success: "#1b9e77",
+    warning: "#d95f02",
+    danger: "#7570b3",
+  },
+  deuteranopia: {
+    primary: "#386cb0",
+    success: "#2ca25f",
+    warning: "#ff7f00",
+    danger: "#984ea3",
+  },
+  tritanopia: {
+    primary: "#009e73",
+    success: "#56b4e9",
+    warning: "#e69f00",
+    danger: "#cc79a7",
+  },
+  achromatopsia: {
+    primary: "#525252",
+    success: "#737373",
+    warning: "#8c8c8c",
+    danger: "#404040",
+  },
+};
+
+const baseLight = {
+  background: "#ffffff",
+  surface: "#f8fafc",
+  surfaceHover: "#f1f5f9",
+  surfaceActive: "#e2e8f0",
+  border: "#cbd5e1"
+};
+
+const baseDark = {
+  background: "#0b1120",
+  surface: "#111827",
+  surfaceHover: "#1e293b",
+  surfaceActive: "#334155",
+  border: "#1f2937",
+};
+
+const lighten = (color: string, amount: number) => mix(color, "#ffffff", amount);
+const darken = (color: string, amount: number) => mix(color, "#000000", amount);
+
+const neutralFromAppearance = (appearance: Appearance) =>
+  appearance === "light" ? "#64748b" : "#94a3b8";
+
+const highContrastBackground = (appearance: Appearance) =>
+  appearance === "light" ? "#ffffff" : "#000000";
+
+const highContrastSurface = (appearance: Appearance) =>
+  appearance === "light" ? "#f4f4f5" : "#111111";
+
+const highContrastText = (appearance: Appearance) =>
+  appearance === "light" ? "#000000" : "#ffffff";
+
+const getAccentColor = (accent: Accent, colorVision: ColorVisionMode) => {
+  if (colorVision !== "normal") {
+    const override = colorVisionSemantics[colorVision].primary;
+    if (override) return override;
+  }
+  return accentPalette[accent];
+};
+
+const getSemanticColor = (
+  key: keyof typeof semanticDefaults,
+  colorVision: ColorVisionMode,
+): string => {
+  const override = colorVisionSemantics[colorVision][key];
+  return override ?? semanticDefaults[key];
+};
+
+const buildSurfacePalette = (appearance: Appearance, highContrast: boolean) => {
+  if (highContrast) {
+    return {
+      background: highContrastBackground(appearance),
+      surface: highContrastSurface(appearance),
+      surfaceHover:
+        appearance === "light" ? "#e4e4e7" : lighten("#111111", 0.12),
+      surfaceActive:
+        appearance === "light" ? "#d4d4d8" : lighten("#111111", 0.2),
+      border: highContrastText(appearance),
+    };
+  }
+  return appearance === "light" ? baseLight : baseDark;
+};
+
+const buildTokens = (options: ThemeOptions): ThemeTokens => {
+  const { appearance, accent, colorVision, highContrast, reducedMotion } = options;
+  const surface = buildSurfacePalette(appearance, highContrast);
+  const accentColor = getAccentColor(accent, colorVision);
+  const neutral = neutralFromAppearance(appearance);
+  const primary = ensureContrast(accentColor, surface.background, highContrast ? 6.5 : 4.5);
+  const success = ensureContrast(
+    appearance === "dark" ? lighten(getSemanticColor("success", colorVision), 0.12) : getSemanticColor("success", colorVision),
+    surface.background,
+    highContrast ? 6 : 4.5,
+  );
+  const warning = ensureContrast(
+    appearance === "dark" ? lighten(getSemanticColor("warning", colorVision), 0.15) : getSemanticColor("warning", colorVision),
+    surface.background,
+    highContrast ? 6 : 4.5,
+  );
+  const danger = ensureContrast(
+    appearance === "dark" ? lighten(getSemanticColor("danger", colorVision), 0.1) : getSemanticColor("danger", colorVision),
+    surface.background,
+    highContrast ? 6 : 4.5,
+  );
+
+  const textBase = highContrast ? highContrastText(appearance) : appearance === "light" ? "#111827" : "#e2e8f0";
+  const textMuted = appearance === "light" ? "#475569" : "#cbd5f5";
+  const textSubtle = appearance === "light" ? "#64748b" : "#94a3b8";
+  const inverted = appearance === "light" ? "#f8fafc" : "#0f172a";
+
+  const neutralSoftBase = appearance === "light" ? lighten(neutral, 0.48) : darken(neutral, 0.4);
+
+  const successSoft = appearance === "light" ? lighten(success, 0.75) : darken(success, 0.55);
+  const successBorder = appearance === "light" ? lighten(success, 0.4) : darken(success, 0.3);
+  const warningSoft = appearance === "light" ? lighten(warning, 0.75) : darken(warning, 0.55);
+  const warningBorder = appearance === "light" ? lighten(warning, 0.4) : darken(warning, 0.3);
+  const dangerSoft = appearance === "light" ? lighten(danger, 0.75) : darken(danger, 0.55);
+  const dangerBorder = appearance === "light" ? lighten(danger, 0.4) : darken(danger, 0.3);
+
+  const tokens: ThemeTokens = {
+    "color-background": surface.background,
+    "color-surface": surface.surface,
+    "color-surface-hover": surface.surfaceHover,
+    "color-surface-active": surface.surfaceActive,
+    "color-border": surface.border,
+    "color-ring": ensureContrast(appearance === "light" ? lighten(primary, 0.2) : darken(primary, 0.2), surface.background, 6),
+    "color-text": textBase,
+    "color-text-subtle": textSubtle,
+    "color-text-muted": textMuted,
+    "color-inverted": inverted,
+    "color-primary": primary,
+    "color-primary-contrast": ensureContrast(
+      appearance === "light" ? "#ffffff" : "#0f172a",
+      primary,
+      highContrast ? 7 : 4.5,
+    ),
+    "color-primary-soft": appearance === "light" ? lighten(primary, 0.72) : darken(primary, 0.6),
+    "color-primary-border": appearance === "light" ? lighten(primary, 0.4) : darken(primary, 0.3),
+    "color-success": success,
+    "color-success-contrast": ensureContrast(appearance === "light" ? "#f8fafc" : "#0f172a", success, highContrast ? 6.5 : 4.5),
+    "color-success-soft": successSoft,
+    "color-success-border": successBorder,
+    "color-warning": warning,
+    "color-warning-contrast": ensureContrast(appearance === "light" ? "#0f172a" : "#f8fafc", warning, highContrast ? 6.5 : 4.5),
+    "color-warning-soft": warningSoft,
+    "color-warning-border": warningBorder,
+    "color-danger": danger,
+    "color-danger-contrast": ensureContrast(appearance === "light" ? "#f8fafc" : "#0f172a", danger, highContrast ? 6.5 : 4.5),
+    "color-danger-soft": dangerSoft,
+    "color-danger-border": dangerBorder,
+    "color-neutral": neutral,
+    "color-neutral-contrast": ensureContrast(appearance === "light" ? "#f8fafc" : "#0f172a", neutral, highContrast ? 6 : 4.5),
+    "color-neutral-soft": neutralSoftBase,
+    "color-neutral-border": appearance === "light" ? lighten(neutral, 0.6) : darken(neutral, 0.55),
+    "font-family-base": "'Inter var', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    "font-family-mono": "'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace",
+    "text-size-xs": "0.75rem",
+    "text-size-sm": "0.875rem",
+    "text-size-md": "1rem",
+    "text-size-lg": "1.125rem",
+    "text-size-xl": "1.25rem",
+    "text-size-2xl": "1.5rem",
+    "line-height-tight": "1.2",
+    "line-height-normal": "1.5",
+    "line-height-relaxed": "1.7",
+    "radius-sm": "0.375rem",
+    "radius-md": "0.5rem",
+    "radius-lg": "0.75rem",
+    "shadow-sm": appearance === "light"
+      ? "0 1px 2px rgba(15, 23, 42, 0.08)"
+      : "0 1px 2px rgba(15, 23, 42, 0.32)",
+    "shadow-md": appearance === "light"
+      ? "0 10px 15px -3px rgba(15, 23, 42, 0.1), 0 4px 6px -4px rgba(15, 23, 42, 0.1)"
+      : "0 12px 24px -6px rgba(15, 23, 42, 0.4)",
+    "shadow-lg": appearance === "light"
+      ? "0 20px 25px -5px rgba(15, 23, 42, 0.18), 0 10px 10px -5px rgba(15, 23, 42, 0.1)"
+      : "0 24px 48px -12px rgba(15, 23, 42, 0.5)",
+    "border-width": highContrast ? "2px" : "1px",
+    "motion-duration": reducedMotion ? "0ms" : "150ms",
+    "motion-ease": reducedMotion ? "linear" : "cubic-bezier(0.4, 0, 0.2, 1)",
+    "spacing-xs": "0.25rem",
+    "spacing-sm": "0.5rem",
+    "spacing-md": "0.75rem",
+    "spacing-lg": "1.25rem",
+  };
+
+  if (colorVision === "achromatopsia") {
+    tokens["color-primary-soft"] = lighten(tokens["color-primary"], appearance === "light" ? 0.6 : 0.3);
+    tokens["color-success"] = ensureContrast(tokens["color-success"], surface.background, 7);
+    tokens["color-warning"] = ensureContrast(tokens["color-warning"], surface.background, 7);
+    tokens["color-danger"] = ensureContrast(tokens["color-danger"], surface.background, 7);
+  }
+
+  if (highContrast) {
+    tokens["shadow-sm"] = "none";
+    tokens["shadow-md"] = "none";
+    tokens["shadow-lg"] = "none";
+  }
+
+  return tokens;
+};
+
+export const createThemeTokens = (options: ThemeOptions): ThemeTokens => buildTokens(options);
+
+export const tokensToCssVariables = (tokens: ThemeTokens): Record<string, string> => {
+  const vars: Record<string, string> = {};
+  (Object.keys(tokens) as ThemeTokenName[]).forEach((token) => {
+    vars[`--mosaic-${token}`] = tokens[token];
+  });
+  return vars;
+};
+
+export const tokenToVar = (token: ThemeTokenName) => `var(--mosaic-${token})`;
+
+export const toCssText = (options: ThemeOptions, tokens: ThemeTokens): string => {
+  const lines = Object.entries(tokens)
+    .map(([key, value]) => `  --mosaic-${key}: ${value};`)
+    .join("\n");
+  return `:root {\n  color-scheme: ${options.appearance};\n${lines}\n}`;
+};

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -1,0 +1,103 @@
+import type { CSSProperties } from "react";
+
+export type Appearance = "light" | "dark";
+export type Accent =
+  | "indigo"
+  | "azure"
+  | "violet"
+  | "emerald"
+  | "amber"
+  | "rose"
+  | "neutral";
+
+export type ColorVisionMode =
+  | "normal"
+  | "protanopia"
+  | "deuteranopia"
+  | "tritanopia"
+  | "achromatopsia";
+
+export interface ThemeOptions {
+  appearance: Appearance;
+  accent: Accent;
+  colorVision: ColorVisionMode;
+  highContrast: boolean;
+  reducedMotion: boolean;
+}
+
+export type ThemeTokenName =
+  | "color-background"
+  | "color-surface"
+  | "color-surface-hover"
+  | "color-surface-active"
+  | "color-border"
+  | "color-ring"
+  | "color-text"
+  | "color-text-subtle"
+  | "color-text-muted"
+  | "color-inverted"
+  | "color-primary"
+  | "color-primary-contrast"
+  | "color-primary-soft"
+  | "color-primary-border"
+  | "color-success"
+  | "color-success-contrast"
+  | "color-success-soft"
+  | "color-success-border"
+  | "color-warning"
+  | "color-warning-contrast"
+  | "color-warning-soft"
+  | "color-warning-border"
+  | "color-danger"
+  | "color-danger-contrast"
+  | "color-danger-soft"
+  | "color-danger-border"
+  | "color-neutral"
+  | "color-neutral-contrast"
+  | "color-neutral-soft"
+  | "color-neutral-border"
+  | "font-family-base"
+  | "font-family-mono"
+  | "text-size-xs"
+  | "text-size-sm"
+  | "text-size-md"
+  | "text-size-lg"
+  | "text-size-xl"
+  | "text-size-2xl"
+  | "line-height-tight"
+  | "line-height-normal"
+  | "line-height-relaxed"
+  | "radius-sm"
+  | "radius-md"
+  | "radius-lg"
+  | "shadow-sm"
+  | "shadow-md"
+  | "shadow-lg"
+  | "border-width"
+  | "motion-duration"
+  | "motion-ease"
+  | "spacing-xs"
+  | "spacing-sm"
+  | "spacing-md"
+  | "spacing-lg";
+
+export type ThemeTokens = Record<ThemeTokenName, string>;
+
+export interface ThemeState extends ThemeOptions {
+  tokens: ThemeTokens;
+}
+
+export interface ThemeContextValue extends ThemeState {
+  setAppearance: (appearance: Appearance) => void;
+  toggleAppearance: () => void;
+  setAccent: (accent: Accent) => void;
+  setColorVision: (mode: ColorVisionMode) => void;
+  setHighContrast: (value: boolean) => void;
+  toggleHighContrast: () => void;
+  setReducedMotion: (value: boolean) => void;
+  toggleReducedMotion: () => void;
+  getVar: (token: ThemeTokenName) => string;
+  cssVariables: CSSProperties;
+}
+
+export type PartialThemeOptions = Partial<ThemeOptions>;

--- a/src/utils/Portal.tsx
+++ b/src/utils/Portal.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useMemo, useState, type PropsWithChildren } from "react";
+import { createPortal } from "react-dom";
+
+const canUseDOM = typeof window !== "undefined" && typeof document !== "undefined";
+
+export interface PortalProps extends PropsWithChildren {
+  container?: HTMLElement | null;
+}
+
+export const Portal = ({ children, container }: PortalProps) => {
+  const [mounted, setMounted] = useState(false);
+  const node = useMemo(() => {
+    if (!canUseDOM) return null;
+    const element = document.createElement("div");
+    element.setAttribute("data-mosaic-portal", "");
+    return element;
+  }, []);
+
+  useEffect(() => {
+    if (!canUseDOM || !node) return;
+    const target = container ?? document.body;
+    target.appendChild(node);
+    setMounted(true);
+    return () => {
+      setMounted(false);
+      if (node.parentElement) {
+        node.parentElement.removeChild(node);
+      }
+    };
+  }, [container, node]);
+
+  if (!canUseDOM || !node || !mounted) {
+    return null;
+  }
+
+  return createPortal(children, node);
+};

--- a/src/utils/cx.ts
+++ b/src/utils/cx.ts
@@ -1,3 +1,29 @@
-export const cx = (
-  ...values: Array<string | undefined | false | null>
-): string => values.filter(Boolean).join(" ");
+type CxValue =
+  | string
+  | false
+  | null
+  | undefined
+  | Record<string, boolean | null | undefined>;
+
+export const cx = (...values: CxValue[]): string => {
+  const classes: string[] = [];
+
+  values.forEach((value) => {
+    if (!value) {
+      return;
+    }
+
+    if (typeof value === "string") {
+      classes.push(value);
+      return;
+    }
+
+    Object.entries(value).forEach(([key, active]) => {
+      if (active) {
+        classes.push(key);
+      }
+    });
+  });
+
+  return classes.join(" ");
+};

--- a/src/utils/cx.ts
+++ b/src/utils/cx.ts
@@ -1,0 +1,3 @@
+export const cx = (
+  ...values: Array<string | undefined | false | null>
+): string => values.filter(Boolean).join(" ");

--- a/src/utils/use-controllable-state.ts
+++ b/src/utils/use-controllable-state.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from "react";
+
+interface UseControllableStateProps<T> {
+  value?: T;
+  defaultValue?: T;
+  onChange?: (value: T) => void;
+}
+
+export const useControllableState = <T,>({
+  value,
+  defaultValue,
+  onChange,
+}: UseControllableStateProps<T>) => {
+  const isControlled = value !== undefined;
+  const [internalValue, setInternalValue] = useState<T | undefined>(defaultValue);
+
+  const setValue = useCallback(
+    (next: T) => {
+      if (!isControlled) {
+        setInternalValue(next);
+      }
+      onChange?.(next);
+    },
+    [isControlled, onChange],
+  );
+
+  return [isControlled ? (value as T) : (internalValue as T), setValue] as const;
+};

--- a/src/utils/use-isomorphic-layout-effect.ts
+++ b/src/utils/use-isomorphic-layout-effect.ts
@@ -1,0 +1,5 @@
+import { useEffect, useLayoutEffect } from "react";
+
+const canUseDOM = typeof window !== "undefined" && typeof document !== "undefined";
+
+export const useIsomorphicLayoutEffect = canUseDOM ? useLayoutEffect : useEffect;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["react"],
+    "types": ["react", "react-dom"],
     "outDir": "dist"
   },
   "include": ["src"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["react"],
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+
+export default defineConfig({
+  root: path.resolve(__dirname, "docs"),
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@mosaic": path.resolve(__dirname, "src"),
+    },
+  },
+  server: {
+    port: 5173,
+    open: false,
+  },
+  preview: {
+    port: 5173,
+  },
+  build: {
+    outDir: path.resolve(__dirname, "dist-docs"),
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- implement a system-aware `ThemeProvider` that persists settings, emits CSS variables, and supports color-vision, high-contrast, and motion-reduction modes
- add accessible component primitives (Button, Card, Text, Stack, Input, Field, VisuallyHidden) styled with shared tokens and utilities
- provide developer tooling with a ThemePanel helper and comprehensive documentation for installing and using the framework

## Testing
- `bun run typecheck`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68d0a6548ce8832e89c0fe8f5bd00b87