### PR TITLE
Set up GitHub Pages deployment for docs site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,47 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build docs site
+        run: bun run docs:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist-docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "dev": "vite --config vite.config.ts",
     "build": "tsc && bun build ./src/index.ts --outdir dist --target bun --sourcemap --external react --external react-dom --external react/jsx-runtime",
+    "docs:build": "vite build --config vite.config.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 export default defineConfig({
   root: path.resolve(__dirname, "docs"),
+  base: "./",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and deploys the docs site to GitHub Pages when changes land on main
- add a Bun script for building the docs and configure the Vite base path so the static build works on Pages

## Testing
- bun run docs:build

------
https://chatgpt.com/codex/tasks/task_e_68d0b6744e1c832e9bae8a033fef3d30