### PR TITLE
Fix command palette controls and escape handling

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -138,6 +138,24 @@ export const Dialog = ({
     };
   }, [open, close]);
 
+  useEffect(() => {
+    if (!open || !canUseDOM) return;
+    const handleDocumentKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (event.defaultPrevented) return;
+      const overlay = overlayRef.current;
+      if (overlay && event.target instanceof Node && !overlay.contains(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      close();
+    };
+    document.addEventListener("keydown", handleDocumentKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleDocumentKeyDown);
+    };
+  }, [close, open]);
+
   const handleOverlayMouseDown = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       if (!closeOnOverlayClick) return;


### PR DESCRIPTION
## Summary
- keep the command palette's active command stable while filtering and expose `openPalette`/`togglePalette` helpers so external triggers work
- fall back to the first available result when necessary to prevent scrolling jumps during search
- listen for Escape at the document level so dialogs and sheets always close from the keyboard

## Testing
- bun run typecheck
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d0c2a94c64832ebb3934fc887209d6