### PR TITLE
Add accessible textarea, select, radio, and slider components

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,12 @@ Use `getCssVar("color-primary")` inside component styles to reference tokens, or
 - `Dialog` & `Sheet` – Modal and slide-over overlays with focus traps and motion awareness.
 - `Field` – Form wrapper that wires labels, hints, and errors to controls automatically.
 - `Input` – Accessible text input with size and validation states.
+- `RadioGroup` & `Radio` – Keyboard navigable sets with descriptions and validation styling.
+- `Select` – Styled native select that adopts Mosaic tokens and focus treatments.
+- `Slider` – Accessible range input with accent-aware focus and error states.
 - `Pagination` – Paginated navigation with ellipsis handling.
 - `Progress` – Determinate and indeterminate indicators with optional labels.
+- `Textarea` – Multi-line input with size controls and shared token styling.
 - `Stack` – Flexbox layout utility for column/row alignment and spacing.
 - `Switch` – Accessible toggle with descriptive text support.
 - `Text` – Semantic typography variants with tone helpers and truncation support.

--- a/docs/App.tsx
+++ b/docs/App.tsx
@@ -12,12 +12,17 @@ import {
   Dialog,
   Field,
   Input,
+  Radio,
+  RadioGroup,
   Pagination,
   Progress,
   Sheet,
+  Select,
+  Slider,
   Stack,
   Switch,
   Text,
+  Textarea,
   ThemePanel,
   Tooltip,
   useCommand,
@@ -138,7 +143,11 @@ const App = () => {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [activePage, setActivePage] = useState(1);
   const [framework, setFramework] = useState<string | null>(languageOptions[0]?.value ?? null);
+  const [priority, setPriority] = useState("normal");
+  const [cadence, setCadence] = useState("daily");
+  const [notes, setNotes] = useState("");
   const [progress, setProgress] = useState(45);
+  const [volume, setVolume] = useState(60);
   const themePanelRef = useRef<HTMLDivElement | null>(null);
   const { toast } = useToast();
   const { togglePalette } = useCommandPalette();
@@ -232,8 +241,55 @@ const App = () => {
                 <Field label="Project start">
                   <DatePicker />
                 </Field>
+                <Field label="Priority">
+                  <Select value={priority} onChange={(event) => setPriority(event.target.value)}>
+                    <option value="low">Low</option>
+                    <option value="normal">Normal</option>
+                    <option value="high">High</option>
+                  </Select>
+                </Field>
               </Stack>
               <Stack direction="row" gap="md" wrap>
+                <Field label="Notes" description="Share context with collaborators before requests ship.">
+                  <Textarea
+                    rows={4}
+                    placeholder="Provide relevant context or requirements"
+                    value={notes}
+                    onChange={(event) => setNotes(event.target.value)}
+                  />
+                </Field>
+                <Field
+                  label="Notification cadence"
+                  description="Choose how often Mosaic sends release updates to stakeholders."
+                >
+                  <RadioGroup value={cadence} onValueChange={setCadence}>
+                    <Radio value="instant" description="Notify everyone the moment changes land.">
+                      Instant
+                    </Radio>
+                    <Radio value="daily" description="Bundle changes into a morning digest.">
+                      Daily
+                    </Radio>
+                    <Radio value="weekly" description="Share a curated summary every Monday.">
+                      Weekly
+                    </Radio>
+                  </RadioGroup>
+                </Field>
+              </Stack>
+              <Stack direction="row" gap="md" wrap align="center">
+                <Field
+                  label="Signal strength"
+                  description="Control how prominent release updates should feel."
+                  hint={`${volume}% emphasis`}
+                >
+                  <Slider
+                    value={volume}
+                    min={0}
+                    max={100}
+                    step={5}
+                    onValueChange={(value) => setVolume(value)}
+                    aria-valuetext={`${volume}% emphasis`}
+                  />
+                </Field>
                 <Switch>Share updates automatically</Switch>
                 <Checkbox description="Invite this teammate to beta features" defaultChecked>
                   Early access

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -39,6 +39,7 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
   ) => {
     const generatedId = useId();
     const fieldId = id ?? `mosaic-field-${generatedId}`;
+    const labelId = label ? `${fieldId}-label` : undefined;
     const descriptionId = description ? `${fieldId}-description` : undefined;
     const hintId = hint ? `${fieldId}-hint` : undefined;
     const errorId = error ? `${fieldId}-error` : undefined;
@@ -48,6 +49,7 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
       const childProps = children.props as Partial<InputProps> & {
         id?: string;
         "aria-describedby"?: string;
+        "aria-labelledby"?: string;
         "aria-invalid"?: boolean | "true" | "false";
       };
       const describedBy = join(
@@ -56,9 +58,11 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
         descriptionId,
         errorId,
       );
+      const labelledBy = join(childProps["aria-labelledby"], labelId);
       control = cloneElement(children, {
         id: childProps.id ?? fieldId,
         "aria-describedby": describedBy || undefined,
+        "aria-labelledby": labelledBy || undefined,
         "aria-invalid": error ? true : childProps["aria-invalid"],
         required: required || childProps.required,
       });
@@ -72,7 +76,7 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(
         {...rest}
       >
         {label ? (
-          <label className="mosaic-field__label" htmlFor={fieldId}>
+          <label className="mosaic-field__label" id={labelId} htmlFor={fieldId}>
             {label}
             {required ? <span className="mosaic-field__required">*</span> : null}
           </label>

--- a/src/components/RadioGroup.tsx
+++ b/src/components/RadioGroup.tsx
@@ -1,0 +1,197 @@
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type HTMLAttributes,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from "react";
+import { cx } from "../utils/cx";
+
+const join = (...values: Array<string | undefined>) => values.filter(Boolean).join(" ");
+
+interface RadioGroupContextValue {
+  name: string;
+  value: string | null;
+  setValue: (value: string) => void;
+  disabled: boolean;
+  required: boolean;
+  describedBy?: string;
+  labelledBy?: string;
+}
+
+const RadioGroupContext = createContext<RadioGroupContextValue | null>(null);
+
+const useRadioGroupContext = () => {
+  const context = useContext(RadioGroupContext);
+  if (!context) {
+    throw new Error("Radio must be used within a RadioGroup");
+  }
+  return context;
+};
+
+export interface RadioGroupProps extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
+  name?: string;
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  disabled?: boolean;
+  required?: boolean;
+  orientation?: "vertical" | "horizontal";
+  invalid?: boolean;
+}
+
+export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
+  (
+    {
+      children,
+      name,
+      value,
+      defaultValue,
+      onValueChange,
+      disabled = false,
+      required = false,
+      orientation = "vertical",
+      className,
+      invalid = false,
+      ...rest
+    },
+    ref,
+  ) => {
+    const generatedName = useId();
+    const groupName = name ?? `mosaic-radio-${generatedName}`;
+    const {
+      "aria-invalid": ariaInvalidProp,
+      "aria-describedby": ariaDescribedBy,
+      "aria-labelledby": ariaLabelledBy,
+      ...restProps
+    } = rest as HTMLAttributes<HTMLDivElement> & {
+      "aria-invalid"?: boolean | "true" | "false";
+      "aria-describedby"?: string;
+      "aria-labelledby"?: string;
+    };
+
+    const isControlled = value !== undefined;
+    const [uncontrolledValue, setUncontrolledValue] = useState<string | undefined>(defaultValue);
+    const selectedValue = (isControlled ? value : uncontrolledValue) ?? null;
+
+    const handleValueChange = useCallback(
+      (next: string) => {
+        if (!isControlled) {
+          setUncontrolledValue(next);
+        }
+        onValueChange?.(next);
+      },
+      [isControlled, onValueChange],
+    );
+
+    const contextValue = useMemo<RadioGroupContextValue>(
+      () => ({
+        name: groupName,
+        value: selectedValue,
+        setValue: handleValueChange,
+        disabled,
+        required,
+        describedBy: ariaDescribedBy,
+        labelledBy: ariaLabelledBy,
+      }),
+      [groupName, selectedValue, handleValueChange, disabled, required, ariaDescribedBy, ariaLabelledBy],
+    );
+
+    const isInvalid = invalid || ariaInvalidProp === true || ariaInvalidProp === "true";
+
+    return (
+      <RadioGroupContext.Provider value={contextValue}>
+        <div
+          {...restProps}
+          ref={ref}
+          role="radiogroup"
+          className={cx("mosaic-radio-group", className)}
+          data-orientation={orientation}
+          data-disabled={disabled ? "true" : undefined}
+          data-invalid={isInvalid ? "true" : undefined}
+          aria-required={required || undefined}
+          aria-invalid={isInvalid || undefined}
+          aria-describedby={ariaDescribedBy}
+          aria-labelledby={ariaLabelledBy}
+        >
+          {children}
+        </div>
+      </RadioGroupContext.Provider>
+    );
+  },
+);
+
+RadioGroup.displayName = "RadioGroup";
+
+export interface RadioProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "type" | "name" | "value" | "defaultChecked" | "checked" | "onChange"> {
+  value: string;
+  description?: ReactNode;
+}
+
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(
+  ({ value, children, description, className, disabled, ...rest }, ref) => {
+    const context = useRadioGroupContext();
+    const generatedId = useId();
+    const {
+      id,
+      onChange,
+      "aria-describedby": ariaDescribedBy,
+      ...restProps
+    } = rest as InputHTMLAttributes<HTMLInputElement> & { "aria-describedby"?: string };
+
+    const inputId = id ?? `${context.name}-${generatedId}`;
+    const descriptionId = description ? `${inputId}-description` : undefined;
+    const isChecked = context.value === value;
+    const isDisabled = context.disabled || disabled;
+    const describedBy = join(context.describedBy, ariaDescribedBy, descriptionId);
+
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      onChange?.(event);
+      if (event.defaultPrevented) return;
+      context.setValue(value);
+    };
+
+    return (
+      <label
+        className={cx("mosaic-radio", className)}
+        data-checked={isChecked ? "true" : undefined}
+        data-disabled={isDisabled ? "true" : undefined}
+      >
+        <span className="mosaic-radio__control">
+          <input
+            {...restProps}
+            ref={ref}
+            id={inputId}
+            type="radio"
+            value={value}
+            name={context.name}
+            className="mosaic-radio__input"
+            checked={isChecked}
+            onChange={handleChange}
+            disabled={isDisabled}
+            required={context.required}
+            aria-describedby={describedBy || undefined}
+          />
+          <span className="mosaic-radio__indicator" aria-hidden="true" />
+        </span>
+        <span className="mosaic-radio__content">
+          {children ? <span className="mosaic-radio__label">{children}</span> : null}
+          {description ? (
+            <span className="mosaic-radio__description" id={descriptionId}>
+              {description}
+            </span>
+          ) : null}
+        </span>
+      </label>
+    );
+  },
+);
+
+Radio.displayName = "Radio";

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,0 +1,54 @@
+import { forwardRef, type CSSProperties, type SelectHTMLAttributes } from "react";
+import { getCssVar } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type SelectSize = "sm" | "md" | "lg";
+
+const sizeMap: Record<SelectSize, Record<string, string>> = {
+  sm: {
+    "--mosaic-select-padding-y": "calc(var(--mosaic-spacing-xs) + 0.1rem)",
+    "--mosaic-select-padding-x": "var(--mosaic-spacing-sm)",
+    "--mosaic-select-font-size": getCssVar("text-size-sm"),
+  },
+  md: {
+    "--mosaic-select-padding-y": "var(--mosaic-spacing-sm)",
+    "--mosaic-select-padding-x": "var(--mosaic-spacing-md)",
+    "--mosaic-select-font-size": getCssVar("text-size-md"),
+  },
+  lg: {
+    "--mosaic-select-padding-y": "calc(var(--mosaic-spacing-md) - 0.05rem)",
+    "--mosaic-select-padding-x": "calc(var(--mosaic-spacing-lg) - 0.1rem)",
+    "--mosaic-select-font-size": getCssVar("text-size-lg"),
+  },
+};
+
+export interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, "size"> {
+  size?: SelectSize;
+  invalid?: boolean;
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  ({ size = "md", className, style: inlineStyle, invalid = false, ...rest }, ref) => {
+    const { "aria-invalid": ariaInvalidProp, ...restProps } = rest as SelectHTMLAttributes<HTMLSelectElement> & {
+      "aria-invalid"?: boolean | "true" | "false";
+    };
+    const sizeVars = sizeMap[size];
+    const styles: CSSProperties = { ...(inlineStyle as CSSProperties | undefined) };
+    Object.assign(styles, sizeVars);
+
+    const isInvalid = invalid || ariaInvalidProp === true || ariaInvalidProp === "true";
+
+    return (
+      <select
+        {...restProps}
+        ref={ref}
+        className={cx("mosaic-select", className)}
+        style={styles}
+        data-invalid={isInvalid ? "true" : undefined}
+        aria-invalid={isInvalid || undefined}
+      />
+    );
+  },
+);
+
+Select.displayName = "Select";

--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -1,0 +1,40 @@
+import { forwardRef, type ChangeEvent, type InputHTMLAttributes } from "react";
+import { cx } from "../utils/cx";
+
+export interface SliderProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "type"> {
+  onValueChange?: (value: number) => void;
+  invalid?: boolean;
+}
+
+export const Slider = forwardRef<HTMLInputElement, SliderProps>(
+  ({ className, onChange, onValueChange, invalid = false, ...rest }, ref) => {
+    const { "aria-invalid": ariaInvalidProp, ...restProps } = rest as InputHTMLAttributes<HTMLInputElement> & {
+      "aria-invalid"?: boolean | "true" | "false";
+    };
+
+    const isInvalid = invalid || ariaInvalidProp === true || ariaInvalidProp === "true";
+
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      onChange?.(event);
+      if (event.defaultPrevented) return;
+      const nextValue = Number(event.target.value);
+      if (!Number.isNaN(nextValue)) {
+        onValueChange?.(nextValue);
+      }
+    };
+
+    return (
+      <input
+        {...restProps}
+        ref={ref}
+        type="range"
+        className={cx("mosaic-slider", className)}
+        onChange={handleChange}
+        data-invalid={isInvalid ? "true" : undefined}
+        aria-invalid={isInvalid || undefined}
+      />
+    );
+  },
+);
+
+Slider.displayName = "Slider";

--- a/src/components/Textarea.tsx
+++ b/src/components/Textarea.tsx
@@ -1,0 +1,54 @@
+import { forwardRef, type CSSProperties, type TextareaHTMLAttributes } from "react";
+import { getCssVar } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+type TextareaSize = "sm" | "md" | "lg";
+
+const sizeMap: Record<TextareaSize, Record<string, string>> = {
+  sm: {
+    "--mosaic-textarea-padding-y": "calc(var(--mosaic-spacing-xs) + 0.1rem)",
+    "--mosaic-textarea-padding-x": "var(--mosaic-spacing-sm)",
+    "--mosaic-textarea-font-size": getCssVar("text-size-sm"),
+  },
+  md: {
+    "--mosaic-textarea-padding-y": "var(--mosaic-spacing-sm)",
+    "--mosaic-textarea-padding-x": "var(--mosaic-spacing-md)",
+    "--mosaic-textarea-font-size": getCssVar("text-size-md"),
+  },
+  lg: {
+    "--mosaic-textarea-padding-y": "calc(var(--mosaic-spacing-md) - 0.05rem)",
+    "--mosaic-textarea-padding-x": "calc(var(--mosaic-spacing-lg) - 0.1rem)",
+    "--mosaic-textarea-font-size": getCssVar("text-size-lg"),
+  },
+};
+
+export interface TextareaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "size"> {
+  size?: TextareaSize;
+  invalid?: boolean;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ size = "md", className, style: inlineStyle, invalid = false, ...rest }, ref) => {
+    const { "aria-invalid": ariaInvalidProp, ...restProps } = rest as TextareaHTMLAttributes<HTMLTextAreaElement> & {
+      "aria-invalid"?: boolean | "true" | "false";
+    };
+    const sizeVars = sizeMap[size];
+    const styles: CSSProperties = { ...(inlineStyle as CSSProperties | undefined) };
+    Object.assign(styles, sizeVars);
+
+    const isInvalid = invalid || ariaInvalidProp === true || ariaInvalidProp === "true";
+
+    return (
+      <textarea
+        {...restProps}
+        ref={ref}
+        className={cx("mosaic-textarea", className)}
+        style={styles}
+        data-invalid={isInvalid ? "true" : undefined}
+        aria-invalid={isInvalid || undefined}
+      />
+    );
+  },
+);
+
+Textarea.displayName = "Textarea";

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,14 @@ export { DatePicker } from "./components/DatePicker";
 export { Dialog } from "./components/Dialog";
 export { Pagination } from "./components/Pagination";
 export { Progress } from "./components/Progress";
+export { RadioGroup, Radio } from "./components/RadioGroup";
 export { Sheet } from "./components/Sheet";
+export { Select } from "./components/Select";
 export { Switch } from "./components/Switch";
+export { Slider } from "./components/Slider";
 export { ToastProvider, useToast } from "./components/Toast";
 export { Tooltip } from "./components/Tooltip";
+export { Textarea } from "./components/Textarea";
 
 export {
   ThemeProvider,

--- a/src/theme/baseStyles.ts
+++ b/src/theme/baseStyles.ts
@@ -252,6 +252,74 @@ export const baseStyles = `
   cursor: not-allowed;
 }
 
+.mosaic-textarea {
+  width: 100%;
+  min-height: 6rem;
+  font: inherit;
+  padding-block: var(--mosaic-textarea-padding-y, var(--mosaic-spacing-sm));
+  padding-inline: var(--mosaic-textarea-padding-x, var(--mosaic-spacing-md));
+  border-radius: var(--mosaic-radius-md);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  background-color: var(--mosaic-color-surface);
+  color: var(--mosaic-color-text);
+  font-size: var(--mosaic-textarea-font-size, var(--mosaic-text-size-md));
+  line-height: var(--mosaic-line-height-normal);
+  resize: vertical;
+  transition: border-color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    box-shadow var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-textarea::placeholder {
+  color: var(--mosaic-color-text-muted);
+}
+
+.mosaic-textarea:focus-visible {
+  outline: none;
+  border-color: var(--mosaic-color-ring);
+  box-shadow: var(--mosaic-focus-ring);
+}
+
+.mosaic-textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.mosaic-select {
+  width: 100%;
+  font: inherit;
+  padding-block: var(--mosaic-select-padding-y, var(--mosaic-spacing-sm));
+  padding-inline: var(--mosaic-select-padding-x, var(--mosaic-spacing-md));
+  padding-inline-end: calc(var(--mosaic-select-padding-x, var(--mosaic-spacing-md)) + 1.75rem);
+  border-radius: var(--mosaic-radius-md);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  background-color: var(--mosaic-color-surface);
+  color: var(--mosaic-color-text);
+  font-size: var(--mosaic-select-font-size, var(--mosaic-text-size-md));
+  line-height: var(--mosaic-line-height-normal);
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--mosaic-color-text-muted) 50%),
+    linear-gradient(135deg, var(--mosaic-color-text-muted) 50%, transparent 50%);
+  background-position: calc(100% - 1.15rem) 52%, calc(100% - 0.65rem) 52%;
+  background-size: 0.45rem 0.45rem;
+  background-repeat: no-repeat;
+  transition: border-color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    box-shadow var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+  cursor: pointer;
+}
+
+.mosaic-select:focus-visible {
+  outline: none;
+  border-color: var(--mosaic-color-ring);
+  box-shadow: var(--mosaic-focus-ring);
+}
+
+.mosaic-select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .mosaic-field {
   display: flex;
   flex-direction: column;
@@ -291,7 +359,20 @@ export const baseStyles = `
   color: var(--mosaic-color-danger);
 }
 
-.mosaic-field[data-invalid="true"] .mosaic-input {
+.mosaic-field[data-invalid="true"] .mosaic-input,
+.mosaic-input[data-invalid="true"] {
+  border-color: var(--mosaic-color-danger);
+  box-shadow: 0 0 0 1px var(--mosaic-color-danger);
+}
+
+.mosaic-field[data-invalid="true"] .mosaic-textarea,
+.mosaic-textarea[data-invalid="true"] {
+  border-color: var(--mosaic-color-danger);
+  box-shadow: 0 0 0 1px var(--mosaic-color-danger);
+}
+
+.mosaic-field[data-invalid="true"] .mosaic-select,
+.mosaic-select[data-invalid="true"] {
   border-color: var(--mosaic-color-danger);
   box-shadow: 0 0 0 1px var(--mosaic-color-danger);
 }
@@ -678,7 +759,8 @@ export const baseStyles = `
 }
 
 .mosaic-switch__description,
-.mosaic-checkbox__description {
+.mosaic-checkbox__description,
+.mosaic-radio__description {
   font-size: var(--mosaic-text-size-sm);
   color: var(--mosaic-color-text-muted);
 }
@@ -740,6 +822,118 @@ export const baseStyles = `
 
 .mosaic-checkbox__label {
   font-weight: 500;
+}
+
+.mosaic-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-sm);
+}
+
+.mosaic-radio-group[data-orientation="horizontal"] {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--mosaic-spacing-md);
+}
+
+.mosaic-radio {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: var(--mosaic-spacing-sm);
+  cursor: pointer;
+  color: var(--mosaic-color-text);
+}
+
+.mosaic-radio[data-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.mosaic-radio__control {
+  position: relative;
+  width: 1.2rem;
+  height: 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mosaic-radio__input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+}
+
+.mosaic-radio__indicator {
+  width: 100%;
+  height: 100%;
+  border-radius: 999px;
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  background: var(--mosaic-color-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    border-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-radio__indicator::after {
+  content: "";
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background-color: transparent;
+  transition: background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-radio__input:checked + .mosaic-radio__indicator {
+  border-color: var(--mosaic-color-primary);
+  background-color: var(--mosaic-color-primary-soft);
+}
+
+.mosaic-radio__input:checked + .mosaic-radio__indicator::after {
+  background-color: var(--mosaic-color-primary);
+}
+
+.mosaic-radio__input:focus-visible + .mosaic-radio__indicator {
+  box-shadow: var(--mosaic-focus-ring);
+}
+
+.mosaic-radio__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.mosaic-radio__label {
+  font-weight: 500;
+}
+
+.mosaic-radio-group[data-invalid="true"] .mosaic-radio__indicator,
+.mosaic-field[data-invalid="true"] .mosaic-radio__indicator,
+.mosaic-radio[data-invalid="true"] .mosaic-radio__indicator {
+  border-color: var(--mosaic-color-danger);
+}
+
+.mosaic-radio-group[data-invalid="true"] .mosaic-radio__input:checked + .mosaic-radio__indicator,
+.mosaic-field[data-invalid="true"] .mosaic-radio__input:checked + .mosaic-radio__indicator,
+.mosaic-radio[data-invalid="true"] .mosaic-radio__input:checked + .mosaic-radio__indicator {
+  background-color: var(--mosaic-color-danger);
+  border-color: var(--mosaic-color-danger);
+}
+
+.mosaic-radio-group[data-invalid="true"] .mosaic-radio__input:checked + .mosaic-radio__indicator::after,
+.mosaic-field[data-invalid="true"] .mosaic-radio__input:checked + .mosaic-radio__indicator::after,
+.mosaic-radio[data-invalid="true"] .mosaic-radio__input:checked + .mosaic-radio__indicator::after {
+  background-color: var(--mosaic-color-danger);
+}
+
+.mosaic-radio-group[data-invalid="true"] .mosaic-radio__input:focus-visible + .mosaic-radio__indicator,
+.mosaic-field[data-invalid="true"] .mosaic-radio__input:focus-visible + .mosaic-radio__indicator,
+.mosaic-radio[data-invalid="true"] .mosaic-radio__input:focus-visible + .mosaic-radio__indicator {
+  box-shadow: 0 0 0 1px var(--mosaic-color-inverted), 0 0 0 4px var(--mosaic-color-danger);
 }
 
 .mosaic-badge {
@@ -845,8 +1039,106 @@ export const baseStyles = `
     transform: translateX(20%);
   }
   100% {
-    transform: translateX(120%);
+    transform: translateX(100%);
   }
+}
+
+.mosaic-slider {
+  width: 100%;
+  display: block;
+  height: 1.25rem;
+  margin: 0;
+  background: transparent;
+  accent-color: var(--mosaic-color-primary);
+  cursor: pointer;
+  touch-action: pan-y;
+}
+
+.mosaic-slider:focus-visible {
+  outline: none;
+}
+
+.mosaic-slider:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.mosaic-slider::-webkit-slider-runnable-track {
+  height: 0.4rem;
+  border-radius: 999px;
+  background-color: var(--mosaic-color-border);
+  transition: background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-slider::-moz-range-track {
+  height: 0.4rem;
+  border-radius: 999px;
+  background-color: var(--mosaic-color-border);
+  transition: background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-slider::-moz-range-progress {
+  height: 0.4rem;
+  border-radius: 999px;
+  background-color: var(--mosaic-color-primary);
+}
+
+.mosaic-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 50%;
+  background-color: var(--mosaic-color-primary);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-primary);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
+  transition: box-shadow var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+  margin-top: -0.35rem;
+}
+
+.mosaic-slider::-moz-range-thumb {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 50%;
+  background-color: var(--mosaic-color-primary);
+  border: var(--mosaic-border-width) solid var(--mosaic-color-primary);
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
+  transition: box-shadow var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-slider:focus-visible::-webkit-slider-thumb {
+  box-shadow: var(--mosaic-focus-ring), 0 2px 6px rgba(15, 23, 42, 0.2);
+}
+
+.mosaic-slider:focus-visible::-moz-range-thumb {
+  box-shadow: var(--mosaic-focus-ring), 0 2px 6px rgba(15, 23, 42, 0.2);
+}
+
+.mosaic-slider[data-invalid="true"],
+.mosaic-field[data-invalid="true"] .mosaic-slider {
+  accent-color: var(--mosaic-color-danger);
+}
+
+.mosaic-slider[data-invalid="true"]::-webkit-slider-thumb,
+.mosaic-field[data-invalid="true"] .mosaic-slider::-webkit-slider-thumb,
+.mosaic-slider[data-invalid="true"]::-moz-range-thumb,
+.mosaic-field[data-invalid="true"] .mosaic-slider::-moz-range-thumb {
+  background-color: var(--mosaic-color-danger);
+  border-color: var(--mosaic-color-danger);
+}
+
+.mosaic-slider[data-invalid="true"]:focus-visible::-webkit-slider-thumb,
+.mosaic-field[data-invalid="true"] .mosaic-slider:focus-visible::-webkit-slider-thumb,
+.mosaic-slider[data-invalid="true"]:focus-visible::-moz-range-thumb,
+.mosaic-field[data-invalid="true"] .mosaic-slider:focus-visible::-moz-range-thumb {
+  box-shadow: 0 0 0 1px var(--mosaic-color-inverted), 0 0 0 4px var(--mosaic-color-danger),
+    0 2px 6px rgba(15, 23, 42, 0.2);
+}
+
+.mosaic-slider[data-invalid="true"]::-moz-range-progress,
+.mosaic-field[data-invalid="true"] .mosaic-slider::-moz-range-progress {
+  background-color: var(--mosaic-color-danger);
 }
 
 .mosaic-date-picker {


### PR DESCRIPTION
## Summary
- add Textarea, Select, RadioGroup/Radio, and Slider primitives that follow Mosaic focus and tone tokens
- wire Field to forward aria-labelledby, update base styles for new controls, and export the primitives
- document the controls in README and surface interactive demos in the docs playground

## Testing
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0cae43f04832e952595dc02202430