### PR TITLE
Add accessible Tabs and Accordion components

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,60 @@ const { appearance, toggleAppearance, highContrast, toggleHighContrast } = useTh
 
 Use `getCssVar("color-primary")` inside component styles to reference tokens, or grab `cssVariables` for inline styles.
 
+### Tabs
+
+`Tabs` exposes a roving-tabindex implementation with automatic or manual activation and horizontal or vertical orientation:
+
+```tsx
+import { Tabs, Text } from "mosaic-ui";
+
+<Tabs defaultValue="overview" activationMode="automatic">
+  <Tabs.List aria-label="Project views">
+    <Tabs.Trigger value="overview">Overview</Tabs.Trigger>
+    <Tabs.Trigger value="activity">Activity</Tabs.Trigger>
+    <Tabs.Trigger value="settings" disabled>
+      Settings
+    </Tabs.Trigger>
+  </Tabs.List>
+  <Tabs.Panel value="overview">
+    <Text variant="body">Give stakeholders a quick health summary.</Text>
+  </Tabs.Panel>
+  <Tabs.Panel value="activity">
+    <Text variant="body">Show audit trails, deploys, and alerts.</Text>
+  </Tabs.Panel>
+  <Tabs.Panel value="settings">
+    <Text variant="body">Configure integrations and access policies.</Text>
+  </Tabs.Panel>
+</Tabs>;
+```
+
+Use `activationMode="manual"` to require <kbd>Enter</kbd>/<kbd>Space</kbd> confirmation, and set `orientation="vertical"` for sidebar layouts. Always label the tab list with `aria-label` or `aria-labelledby` when no visible heading is present.
+
+### Accordion
+
+`Accordion` renders collapsible sections with arrow-key navigation. Choose `type="single"` (default) for an allow-one-open experience, or `type="multiple"` to keep several panels expanded.
+
+```tsx
+import { Accordion, Text } from "mosaic-ui";
+
+<Accordion defaultValue="notifications" collapsible>
+  <Accordion.Item value="notifications">
+    <Accordion.Trigger>Email notifications</Accordion.Trigger>
+    <Accordion.Content>
+      <Text variant="body">Send weekly digests and escalation alerts to collaborators.</Text>
+    </Accordion.Content>
+  </Accordion.Item>
+  <Accordion.Item value="integrations">
+    <Accordion.Trigger>Integrations</Accordion.Trigger>
+    <Accordion.Content>
+      <Text variant="body">Connect to Slack, PagerDuty, or a custom webhook destination.</Text>
+    </Accordion.Content>
+  </Accordion.Item>
+</Accordion>;
+```
+
+Pass an array to `defaultValue`/`value` when `type="multiple"`, and set `collapsible` to `true` on single accordions to allow toggling the final open section closed.
+
 ### Components
 
 - `Avatar` – Adaptive initials and imagery with sizing and fallback states.
@@ -124,6 +178,8 @@ Use `getCssVar("color-primary")` inside component styles to reference tokens, or
 - `Field` – Form wrapper that wires labels, hints, and errors to controls automatically.
 - `Input` – Accessible text input with size and validation states.
 - `RadioGroup` & `Radio` – Keyboard navigable sets with descriptions and validation styling.
+- `Tabs` – Orientation-aware tablist with roving focus, manual/automatic activation, and accessible panels.
+- `Accordion` – Arrow-key navigable disclosure with single or multiple expansion modes.
 - `Select` – Styled native select that adopts Mosaic tokens and focus treatments.
 - `Slider` – Accessible range input with accent-aware focus and error states.
 - `Pagination` – Paginated navigation with ellipsis handling.

--- a/docs/App.tsx
+++ b/docs/App.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import {
+  Accordion,
   Avatar,
   Badge,
   Button,
@@ -21,6 +22,7 @@ import {
   Slider,
   Stack,
   Switch,
+  Tabs,
   Text,
   Textarea,
   ThemePanel,
@@ -145,6 +147,7 @@ const App = () => {
   const [framework, setFramework] = useState<string | null>(languageOptions[0]?.value ?? null);
   const [priority, setPriority] = useState("normal");
   const [cadence, setCadence] = useState("daily");
+  const [activeTab, setActiveTab] = useState("overview");
   const [notes, setNotes] = useState("");
   const [progress, setProgress] = useState(45);
   const [volume, setVolume] = useState(60);
@@ -361,6 +364,72 @@ const App = () => {
                   Speed up
                 </Button>
               </Stack>
+            </Stack>
+          </Card>
+        </section>
+
+        <section>
+          <Text variant="title">Navigation & disclosure</Text>
+          <Card className="app-panel" shadow="md">
+            <Stack gap="lg">
+              <Tabs value={activeTab} onValueChange={setActiveTab} activationMode="manual">
+                <Tabs.List aria-label="Workspace snapshots">
+                  <Tabs.Trigger value="overview">Overview</Tabs.Trigger>
+                  <Tabs.Trigger value="reports">Reports</Tabs.Trigger>
+                  <Tabs.Trigger value="activity">Activity</Tabs.Trigger>
+                </Tabs.List>
+                <Tabs.Panel value="overview">
+                  <Stack gap="xs">
+                    <Text variant="label">Team overview</Text>
+                    <Text variant="body">
+                      Summarize platform health, adoption momentum, and active initiatives in one glance.
+                    </Text>
+                  </Stack>
+                </Tabs.Panel>
+                <Tabs.Panel value="reports">
+                  <Stack gap="xs">
+                    <Text variant="label">Automated reports</Text>
+                    <Text variant="body">
+                      Schedule weekly scorecards with exportable CSVs and shareable dashboards.
+                    </Text>
+                  </Stack>
+                </Tabs.Panel>
+                <Tabs.Panel value="activity">
+                  <Stack gap="xs">
+                    <Text variant="label">Recent activity</Text>
+                    <Text variant="body">
+                      Track deployments, approvals, and escalations with keyboard shortcuts and deep links.
+                    </Text>
+                  </Stack>
+                </Tabs.Panel>
+              </Tabs>
+              <Text variant="caption">Active tab: {activeTab}</Text>
+              <Accordion type="multiple" defaultValue={["announcements"]}>
+                <Accordion.Item value="announcements">
+                  <Accordion.Trigger>Announcements</Accordion.Trigger>
+                  <Accordion.Content>
+                    <Stack gap="xs">
+                      <Text variant="body">Broadcast launch notes, downtime notices, and success stories.</Text>
+                      <Text variant="caption">Subscribers: product, sales, leadership</Text>
+                    </Stack>
+                  </Accordion.Content>
+                </Accordion.Item>
+                <Accordion.Item value="reminders">
+                  <Accordion.Trigger>Reminders</Accordion.Trigger>
+                  <Accordion.Content>
+                    <Stack gap="xs">
+                      <Text variant="body">Automate nudges for incomplete reviews and stale follow-ups.</Text>
+                      <Text variant="caption">Triggers every weekday at 9:00am</Text>
+                    </Stack>
+                  </Accordion.Content>
+                </Accordion.Item>
+                <Accordion.Item value="archived" disabled>
+                  <Accordion.Trigger>Archived streams</Accordion.Trigger>
+                  <Accordion.Content>
+                    <Text variant="body">Legacy content stays available for auditors and future retrospectives.</Text>
+                  </Accordion.Content>
+                </Accordion.Item>
+              </Accordion>
             </Stack>
           </Card>
         </section>

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -1,0 +1,504 @@
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ButtonHTMLAttributes,
+  type ForwardRefExoticComponent,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type MouseEvent,
+  type RefAttributes,
+} from "react";
+import { cx } from "../utils/cx";
+import { useIsomorphicLayoutEffect } from "../utils/use-isomorphic-layout-effect";
+
+const sanitizeValue = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, "-");
+
+type AccordionType = "single" | "multiple";
+
+interface AccordionContextValue {
+  type: AccordionType;
+  openValues: string[];
+  collapsible: boolean;
+  registerValue: (value: string) => () => void;
+  setTriggerNode: (value: string, node: HTMLButtonElement | null) => void;
+  setTriggerDisabled: (value: string, disabled: boolean) => void;
+  isItemOpen: (value: string) => boolean;
+  toggleValue: (value: string) => void;
+  moveFocus: (currentValue: string, direction: 1 | -1) => void;
+  focusFirst: () => void;
+  focusLast: () => void;
+  getTriggerId: (value: string) => string;
+  getContentId: (value: string) => string;
+}
+
+const AccordionContext = createContext<AccordionContextValue | null>(null);
+
+const useAccordionContext = () => {
+  const context = useContext(AccordionContext);
+  if (!context) {
+    throw new Error("Accordion components must be used within <Accordion>");
+  }
+  return context;
+};
+
+interface AccordionItemContextValue {
+  value: string;
+  disabled: boolean;
+}
+
+const AccordionItemContext = createContext<AccordionItemContextValue | null>(null);
+
+const useAccordionItemContext = () => {
+  const context = useContext(AccordionItemContext);
+  if (!context) {
+    throw new Error("Accordion.Trigger and Accordion.Content must be inside Accordion.Item");
+  }
+  return context;
+};
+
+export interface AccordionProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "defaultValue" | "value"> {
+  type?: AccordionType;
+  value?: string | string[] | null;
+  defaultValue?: string | string[] | null;
+  onValueChange?: (value: string | string[] | null) => void;
+  collapsible?: boolean;
+}
+
+const normalizeValue = (value: string | string[] | null | undefined, type: AccordionType) => {
+  if (value === undefined) return undefined;
+  if (value === null) return [] as string[];
+  if (Array.isArray(value)) {
+    return type === "multiple" ? [...value] : value.slice(0, 1);
+  }
+  return [value];
+};
+
+const AccordionRoot = forwardRef<HTMLDivElement, AccordionProps>(
+  (
+    {
+      children,
+      type = "single",
+      value: valueProp,
+      defaultValue,
+      onValueChange,
+      collapsible = false,
+      className,
+      ...rest
+    },
+    ref,
+  ) => {
+    const normalizedValue = normalizeValue(valueProp, type);
+    const normalizedDefault = normalizeValue(defaultValue, type) ?? [];
+
+    const isControlled = normalizedValue !== undefined;
+    const isControlledRef = useRef(isControlled);
+    isControlledRef.current = isControlled;
+
+    const [internalOpenValues, setInternalOpenValues] = useState<string[]>(normalizedDefault);
+    const openValues = (isControlled ? normalizedValue : internalOpenValues) ?? [];
+    const openValuesRef = useRef(openValues);
+    openValuesRef.current = openValues;
+
+    const onValueChangeRef = useRef(onValueChange);
+    onValueChangeRef.current = onValueChange;
+
+    const typeRef = useRef(type);
+    typeRef.current = type;
+
+    const collapsibleRef = useRef(collapsible);
+    collapsibleRef.current = collapsible;
+
+    const idPrefix = useId();
+
+    const triggerRefs = useRef<Map<string, { node: HTMLButtonElement | null; disabled: boolean }>>(new Map());
+    const orderedValuesRef = useRef<string[]>([]);
+    const valueIdsRef = useRef<Map<string, string>>(new Map());
+
+    const setOpenValues = useCallback(
+      (next: string[]) => {
+        const current = openValuesRef.current;
+        const hasChanged =
+          current.length !== next.length || current.some((value, index) => value !== next[index]);
+        if (!hasChanged) {
+          return;
+        }
+
+        if (!isControlledRef.current) {
+          setInternalOpenValues(next);
+          openValuesRef.current = next;
+        }
+
+        const handler = onValueChangeRef.current;
+        if (handler) {
+          if (typeRef.current === "multiple") {
+            handler(next);
+          } else {
+            handler(next[0] ?? null);
+          }
+        }
+      },
+      [setInternalOpenValues],
+    );
+
+    const registerValue = useCallback(
+      (value: string) => {
+        if (!orderedValuesRef.current.includes(value)) {
+          orderedValuesRef.current.push(value);
+        }
+        if (!triggerRefs.current.has(value)) {
+          triggerRefs.current.set(value, { node: null, disabled: false });
+        }
+        if (!valueIdsRef.current.has(value)) {
+          const unique = `${sanitizeValue(value)}-${valueIdsRef.current.size + 1}`;
+          valueIdsRef.current.set(value, unique);
+        }
+
+        return () => {
+          orderedValuesRef.current = orderedValuesRef.current.filter((item) => item !== value);
+          triggerRefs.current.delete(value);
+          valueIdsRef.current.delete(value);
+
+          if (openValuesRef.current.includes(value)) {
+            const next = openValuesRef.current.filter((item) => item !== value);
+            setOpenValues(next);
+          }
+        };
+      },
+      [setOpenValues],
+    );
+
+    const setTriggerNode = useCallback((value: string, node: HTMLButtonElement | null) => {
+      const entry = triggerRefs.current.get(value);
+      if (entry) {
+        entry.node = node;
+      } else {
+        triggerRefs.current.set(value, { node, disabled: false });
+      }
+    }, []);
+
+    const setTriggerDisabled = useCallback(
+      (value: string, disabled: boolean) => {
+        const entry = triggerRefs.current.get(value);
+        if (entry) {
+          entry.disabled = disabled;
+        } else {
+          triggerRefs.current.set(value, { node: null, disabled });
+        }
+
+        if (disabled && openValuesRef.current.includes(value)) {
+          const next = openValuesRef.current.filter((item) => item !== value);
+          setOpenValues(next);
+        }
+      },
+      [setOpenValues],
+    );
+
+    const focusValue = useCallback((value: string) => {
+      const entry = triggerRefs.current.get(value);
+      entry?.node?.focus();
+    }, []);
+
+    const moveFocus = useCallback(
+      (currentValue: string, direction: 1 | -1) => {
+        const enabledValues = orderedValuesRef.current.filter((value) => {
+          const entry = triggerRefs.current.get(value);
+          return entry && !entry.disabled;
+        });
+        if (enabledValues.length === 0) {
+          return;
+        }
+
+        const currentIndex = enabledValues.indexOf(currentValue);
+        let nextIndex: number;
+        if (currentIndex === -1) {
+          nextIndex = direction === 1 ? 0 : enabledValues.length - 1;
+        } else {
+          nextIndex = (currentIndex + direction + enabledValues.length) % enabledValues.length;
+        }
+
+        const nextValue = enabledValues[nextIndex];
+        focusValue(nextValue);
+      },
+      [focusValue],
+    );
+
+    const focusFirst = useCallback(() => {
+      for (const value of orderedValuesRef.current) {
+        const entry = triggerRefs.current.get(value);
+        if (entry && !entry.disabled) {
+          focusValue(value);
+          break;
+        }
+      }
+    }, [focusValue]);
+
+    const focusLast = useCallback(() => {
+      const values = orderedValuesRef.current;
+      for (let index = values.length - 1; index >= 0; index -= 1) {
+        const value = values[index];
+        const entry = triggerRefs.current.get(value);
+        if (entry && !entry.disabled) {
+          focusValue(value);
+          break;
+        }
+      }
+    }, [focusValue]);
+
+    const toggleValue = useCallback(
+      (value: string) => {
+        const current = openValuesRef.current;
+        const isOpen = current.includes(value);
+        let next: string[];
+
+        if (typeRef.current === "multiple") {
+          next = isOpen ? current.filter((item) => item !== value) : [...current, value];
+        } else {
+          if (isOpen) {
+            if (!collapsibleRef.current) {
+              return;
+            }
+            next = [];
+          } else {
+            next = [value];
+          }
+        }
+
+        const hasChanged =
+          current.length !== next.length || current.some((item, index) => item !== next[index]);
+        if (!hasChanged) {
+          return;
+        }
+
+        setOpenValues(next);
+      },
+      [setOpenValues],
+    );
+
+    const getTriggerId = useCallback(
+      (value: string) => {
+        const unique = valueIdsRef.current.get(value) ?? sanitizeValue(value);
+        return `mosaic-accordion-${idPrefix}-${unique}-trigger`;
+      },
+      [idPrefix],
+    );
+
+    const getContentId = useCallback(
+      (value: string) => {
+        const unique = valueIdsRef.current.get(value) ?? sanitizeValue(value);
+        return `mosaic-accordion-${idPrefix}-${unique}-content`;
+      },
+      [idPrefix],
+    );
+
+    const contextValue = useMemo<AccordionContextValue>(
+      () => ({
+        type,
+        openValues,
+        collapsible,
+        registerValue,
+        setTriggerNode,
+        setTriggerDisabled,
+        isItemOpen: (value: string) => openValues.includes(value),
+        toggleValue,
+        moveFocus,
+        focusFirst,
+        focusLast,
+        getTriggerId,
+        getContentId,
+      }),
+      [
+        collapsible,
+        focusFirst,
+        focusLast,
+        getContentId,
+        getTriggerId,
+        moveFocus,
+        openValues,
+        registerValue,
+        setTriggerDisabled,
+        setTriggerNode,
+        toggleValue,
+        type,
+      ],
+    );
+
+    return (
+      <AccordionContext.Provider value={contextValue}>
+        <div
+          {...rest}
+          ref={ref}
+          className={cx("mosaic-accordion", className)}
+          data-type={type}
+          data-collapsible={collapsible ? "true" : undefined}
+        >
+          {children}
+        </div>
+      </AccordionContext.Provider>
+    );
+  },
+);
+
+AccordionRoot.displayName = "Accordion";
+
+export interface AccordionItemProps extends HTMLAttributes<HTMLDivElement> {
+  value: string;
+  disabled?: boolean;
+}
+
+const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
+  ({ value, disabled = false, className, children, ...rest }, ref) => {
+    const context = useAccordionContext();
+
+    useIsomorphicLayoutEffect(() => context.registerValue(value), [context, value]);
+
+    const itemContext = useMemo<AccordionItemContextValue>(
+      () => ({ value, disabled }),
+      [value, disabled],
+    );
+
+    const isOpen = context.isItemOpen(value);
+
+    return (
+      <AccordionItemContext.Provider value={itemContext}>
+        <div
+          {...rest}
+          ref={ref}
+          className={cx("mosaic-accordion__item", className)}
+          data-state={isOpen ? "open" : "closed"}
+          data-disabled={disabled ? "true" : undefined}
+        >
+          {children}
+        </div>
+      </AccordionItemContext.Provider>
+    );
+  },
+);
+
+AccordionItem.displayName = "Accordion.Item";
+
+export interface AccordionTriggerProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type"> {}
+
+const AccordionTrigger = forwardRef<HTMLButtonElement, AccordionTriggerProps>(
+  ({ className, onClick, onKeyDown, disabled: disabledProp = false, children, ...rest }, ref) => {
+    const context = useAccordionContext();
+    const item = useAccordionItemContext();
+    const value = item.value;
+    const isDisabled = item.disabled || disabledProp;
+
+    const setRef = useCallback(
+      (node: HTMLButtonElement | null) => {
+        context.setTriggerNode(value, node);
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [context, ref, value],
+    );
+
+    useIsomorphicLayoutEffect(() => {
+      context.setTriggerDisabled(value, isDisabled);
+    }, [context, value, isDisabled]);
+
+    const isOpen = context.isItemOpen(value);
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented || isDisabled) return;
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        context.moveFocus(value, 1);
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        context.moveFocus(value, -1);
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        context.focusFirst();
+      } else if (event.key === "End") {
+        event.preventDefault();
+        context.focusLast();
+      } else if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        context.toggleValue(value);
+      }
+    };
+
+    const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented || isDisabled) return;
+      context.toggleValue(value);
+    };
+
+    return (
+      <button
+        {...rest}
+        ref={setRef}
+        type="button"
+        className={cx("mosaic-accordion__trigger", className)}
+        data-state={isOpen ? "open" : "closed"}
+        data-disabled={isDisabled ? "true" : undefined}
+        aria-expanded={isOpen}
+        aria-controls={context.getContentId(value)}
+        id={context.getTriggerId(value)}
+        disabled={isDisabled}
+        onKeyDown={handleKeyDown}
+        onClick={handleClick}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+AccordionTrigger.displayName = "Accordion.Trigger";
+
+export interface AccordionContentProps extends HTMLAttributes<HTMLDivElement> {}
+
+const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
+  ({ className, children, ...rest }, ref) => {
+    const context = useAccordionContext();
+    const item = useAccordionItemContext();
+    const isOpen = context.isItemOpen(item.value);
+
+    return (
+      <div
+        {...rest}
+        ref={ref}
+        id={context.getContentId(item.value)}
+        role="region"
+        aria-labelledby={context.getTriggerId(item.value)}
+        hidden={!isOpen}
+        aria-hidden={!isOpen}
+        className={cx("mosaic-accordion__content", className)}
+        data-state={isOpen ? "open" : "closed"}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+AccordionContent.displayName = "Accordion.Content";
+
+export interface AccordionComponent
+  extends ForwardRefExoticComponent<AccordionProps & RefAttributes<HTMLDivElement>> {
+  Item: typeof AccordionItem;
+  Trigger: typeof AccordionTrigger;
+  Content: typeof AccordionContent;
+}
+
+export const Accordion = Object.assign(AccordionRoot, {
+  Item: AccordionItem,
+  Trigger: AccordionTrigger,
+  Content: AccordionContent,
+}) as AccordionComponent;
+

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,0 +1,455 @@
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useRef,
+  type ButtonHTMLAttributes,
+  type ForwardRefExoticComponent,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type MouseEvent,
+  type RefAttributes,
+} from "react";
+import { cx } from "../utils/cx";
+import { useControllableState } from "../utils/use-controllable-state";
+import { useIsomorphicLayoutEffect } from "../utils/use-isomorphic-layout-effect";
+
+const sanitizeValue = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, "-");
+
+type TabsOrientation = "horizontal" | "vertical";
+type TabsActivationMode = "automatic" | "manual";
+
+interface TriggerRecord {
+  node: HTMLButtonElement | null;
+  disabled: boolean;
+}
+
+interface TabsContextValue {
+  value: string | null;
+  orientation: TabsOrientation;
+  activationMode: TabsActivationMode;
+  registerValue: (value: string) => () => void;
+  setTriggerNode: (value: string, node: HTMLButtonElement | null) => void;
+  setTriggerDisabled: (value: string, disabled: boolean) => void;
+  selectValue: (value: string) => void;
+  getFirstEnabledValue: () => string | undefined;
+  moveFocus: (currentValue: string | null, direction: 1 | -1) => void;
+  focusFirst: () => void;
+  focusLast: () => void;
+  getTriggerId: (value: string) => string;
+  getPanelId: (value: string) => string;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+const useTabsContext = () => {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error("Tabs components must be used within <Tabs>");
+  }
+  return context;
+};
+
+export interface TabsProps extends HTMLAttributes<HTMLDivElement> {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  orientation?: TabsOrientation;
+  activationMode?: TabsActivationMode;
+}
+
+const TabsRoot = forwardRef<HTMLDivElement, TabsProps>(
+  (
+    {
+      children,
+      value: valueProp,
+      defaultValue,
+      onValueChange,
+      orientation = "horizontal",
+      activationMode = "automatic",
+      className,
+      ...rest
+    },
+    ref,
+  ) => {
+    const [selectedValue, setSelectedValue] = useControllableState<string | null>({
+      value: valueProp,
+      defaultValue: defaultValue ?? null,
+      onChange: (next) => {
+        if (next !== null) {
+          onValueChange?.(next);
+        }
+      },
+    });
+
+    const isControlled = valueProp !== undefined;
+    const isControlledRef = useRef(isControlled);
+    isControlledRef.current = isControlled;
+    const selectedValueRef = useRef<string | null>(selectedValue);
+    selectedValueRef.current = selectedValue;
+
+    const setSelectedValueSafely = useCallback(
+      (next: string | null) => {
+        if (selectedValueRef.current === next) {
+          return;
+        }
+        setSelectedValue(next);
+      },
+      [setSelectedValue],
+    );
+
+    const selectValue = useCallback(
+      (next: string) => {
+        setSelectedValueSafely(next);
+      },
+      [setSelectedValueSafely],
+    );
+
+    const triggerRefs = useRef<Map<string, TriggerRecord>>(new Map());
+    const orderedValuesRef = useRef<string[]>([]);
+    const valueIdsRef = useRef<Map<string, string>>(new Map());
+    const idPrefix = useId();
+
+    const getFirstEnabledValue = useCallback(() => {
+      for (const value of orderedValuesRef.current) {
+        const entry = triggerRefs.current.get(value);
+        if (entry && !entry.disabled) {
+          return value;
+        }
+      }
+      return undefined;
+    }, []);
+
+    const registerValue = useCallback(
+      (value: string) => {
+        if (!orderedValuesRef.current.includes(value)) {
+          orderedValuesRef.current.push(value);
+        }
+        if (!triggerRefs.current.has(value)) {
+          triggerRefs.current.set(value, { node: null, disabled: false });
+        }
+        if (!valueIdsRef.current.has(value)) {
+          const unique = `${sanitizeValue(value)}-${valueIdsRef.current.size + 1}`;
+          valueIdsRef.current.set(value, unique);
+        }
+        if (!isControlledRef.current) {
+          const firstEnabled = getFirstEnabledValue();
+          if (firstEnabled && selectedValueRef.current == null) {
+            setSelectedValueSafely(firstEnabled);
+          }
+        }
+
+        return () => {
+          orderedValuesRef.current = orderedValuesRef.current.filter((item) => item !== value);
+          triggerRefs.current.delete(value);
+          valueIdsRef.current.delete(value);
+
+          if (!isControlledRef.current && selectedValueRef.current === value) {
+            const nextValue = getFirstEnabledValue();
+            setSelectedValueSafely(nextValue ?? null);
+          }
+        };
+      },
+      [getFirstEnabledValue, setSelectedValueSafely],
+    );
+
+    const setTriggerNode = useCallback((value: string, node: HTMLButtonElement | null) => {
+      const entry = triggerRefs.current.get(value);
+      if (entry) {
+        entry.node = node;
+      } else {
+        triggerRefs.current.set(value, { node, disabled: false });
+      }
+    }, []);
+
+    const setTriggerDisabled = useCallback(
+      (value: string, disabled: boolean) => {
+        const entry = triggerRefs.current.get(value);
+        if (entry) {
+          entry.disabled = disabled;
+        } else {
+          triggerRefs.current.set(value, { node: null, disabled });
+        }
+
+        if (!isControlledRef.current && disabled && selectedValueRef.current === value) {
+          const nextValue = getFirstEnabledValue();
+          setSelectedValueSafely(nextValue ?? null);
+        }
+      },
+      [getFirstEnabledValue, setSelectedValueSafely],
+    );
+
+    const focusValue = useCallback((value: string) => {
+      const entry = triggerRefs.current.get(value);
+      entry?.node?.focus();
+    }, []);
+
+    const moveFocus = useCallback(
+      (currentValue: string | null, direction: 1 | -1) => {
+        const enabledValues = orderedValuesRef.current.filter((value) => {
+          const entry = triggerRefs.current.get(value);
+          return entry && !entry.disabled;
+        });
+        if (enabledValues.length === 0) {
+          return;
+        }
+
+        const currentIndex = currentValue ? enabledValues.indexOf(currentValue) : -1;
+        let nextIndex: number;
+        if (currentIndex === -1) {
+          nextIndex = direction === 1 ? 0 : enabledValues.length - 1;
+        } else {
+          nextIndex = (currentIndex + direction + enabledValues.length) % enabledValues.length;
+        }
+
+        const nextValue = enabledValues[nextIndex];
+        focusValue(nextValue);
+        if (activationMode === "automatic") {
+          setSelectedValueSafely(nextValue);
+        }
+      },
+      [activationMode, focusValue, setSelectedValueSafely],
+    );
+
+    const focusFirst = useCallback(() => {
+      const firstEnabled = getFirstEnabledValue();
+      if (!firstEnabled) return;
+      focusValue(firstEnabled);
+      if (activationMode === "automatic") {
+        setSelectedValueSafely(firstEnabled);
+      }
+    }, [activationMode, focusValue, getFirstEnabledValue, setSelectedValueSafely]);
+
+    const focusLast = useCallback(() => {
+      const enabledValues = orderedValuesRef.current.filter((value) => {
+        const entry = triggerRefs.current.get(value);
+        return entry && !entry.disabled;
+      });
+      if (enabledValues.length === 0) {
+        return;
+      }
+      const lastValue = enabledValues[enabledValues.length - 1];
+      focusValue(lastValue);
+      if (activationMode === "automatic") {
+        setSelectedValueSafely(lastValue);
+      }
+    }, [activationMode, focusValue, setSelectedValueSafely]);
+
+    const getTriggerId = useCallback(
+      (value: string) => {
+        const unique = valueIdsRef.current.get(value) ?? sanitizeValue(value);
+        return `mosaic-tab-${idPrefix}-${unique}-trigger`;
+      },
+      [idPrefix],
+    );
+
+    const getPanelId = useCallback(
+      (value: string) => {
+        const unique = valueIdsRef.current.get(value) ?? sanitizeValue(value);
+        return `mosaic-tab-${idPrefix}-${unique}-panel`;
+      },
+      [idPrefix],
+    );
+
+    const contextValue = useMemo<TabsContextValue>(
+      () => ({
+        value: selectedValue,
+        orientation,
+        activationMode,
+        registerValue,
+        setTriggerNode,
+        setTriggerDisabled,
+        selectValue,
+        getFirstEnabledValue,
+        moveFocus,
+        focusFirst,
+        focusLast,
+        getTriggerId,
+        getPanelId,
+      }),
+      [
+        activationMode,
+        focusFirst,
+        focusLast,
+        getFirstEnabledValue,
+        getPanelId,
+        getTriggerId,
+        moveFocus,
+        orientation,
+        registerValue,
+        selectedValue,
+        selectValue,
+        setTriggerDisabled,
+        setTriggerNode,
+      ],
+    );
+
+    return (
+      <TabsContext.Provider value={contextValue}>
+        <div
+          {...rest}
+          ref={ref}
+          className={cx("mosaic-tabs", className)}
+          data-orientation={orientation}
+          data-activation={activationMode}
+        >
+          {children}
+        </div>
+      </TabsContext.Provider>
+    );
+  },
+);
+
+TabsRoot.displayName = "Tabs";
+
+export interface TabsListProps extends HTMLAttributes<HTMLDivElement> {}
+
+const TabsList = forwardRef<HTMLDivElement, TabsListProps>(({ className, ...rest }, ref) => {
+  const { orientation } = useTabsContext();
+  return (
+    <div
+      {...rest}
+      ref={ref}
+      role="tablist"
+      aria-orientation={orientation}
+      className={cx("mosaic-tabs__list", className)}
+      data-orientation={orientation}
+    />
+  );
+});
+
+TabsList.displayName = "Tabs.List";
+
+export interface TabsTriggerProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type"> {
+  value: string;
+}
+
+const TabsTrigger = forwardRef<HTMLButtonElement, TabsTriggerProps>(
+  ({ value, className, disabled = false, onKeyDown, onClick, children, ...rest }, ref) => {
+    const context = useTabsContext();
+
+    useIsomorphicLayoutEffect(() => context.registerValue(value), [context, value]);
+
+    const setRef = useCallback(
+      (node: HTMLButtonElement | null) => {
+        context.setTriggerNode(value, node);
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [context, ref, value],
+    );
+
+    useIsomorphicLayoutEffect(() => {
+      context.setTriggerDisabled(value, disabled);
+    }, [context, value, disabled]);
+
+    const isSelected = context.value === value;
+    const firstEnabled = context.getFirstEnabledValue();
+    const isFocusable = isSelected || (!context.value && firstEnabled === value);
+    const tabIndex = disabled ? -1 : isFocusable ? 0 : -1;
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented || disabled) return;
+
+      const isHorizontal = context.orientation === "horizontal";
+      if (event.key === "ArrowRight" && isHorizontal) {
+        event.preventDefault();
+        context.moveFocus(value, 1);
+      } else if (event.key === "ArrowLeft" && isHorizontal) {
+        event.preventDefault();
+        context.moveFocus(value, -1);
+      } else if (event.key === "ArrowDown" && context.orientation === "vertical") {
+        event.preventDefault();
+        context.moveFocus(value, 1);
+      } else if (event.key === "ArrowUp" && context.orientation === "vertical") {
+        event.preventDefault();
+        context.moveFocus(value, -1);
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        context.focusFirst();
+      } else if (event.key === "End") {
+        event.preventDefault();
+        context.focusLast();
+      } else if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        context.selectValue(value);
+      }
+    };
+
+    const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (event.defaultPrevented || disabled) return;
+      context.selectValue(value);
+    };
+
+    return (
+      <button
+        {...rest}
+        ref={setRef}
+        role="tab"
+        type="button"
+        id={context.getTriggerId(value)}
+        className={cx("mosaic-tabs__trigger", className)}
+        aria-selected={isSelected}
+        aria-controls={context.getPanelId(value)}
+        tabIndex={tabIndex}
+        data-state={isSelected ? "active" : "inactive"}
+        data-disabled={disabled ? "true" : undefined}
+        disabled={disabled}
+        onKeyDown={handleKeyDown}
+        onClick={handleClick}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+TabsTrigger.displayName = "Tabs.Trigger";
+
+export interface TabsPanelProps extends HTMLAttributes<HTMLDivElement> {
+  value: string;
+}
+
+const TabsPanel = forwardRef<HTMLDivElement, TabsPanelProps>(({ value, className, children, ...rest }, ref) => {
+  const context = useTabsContext();
+  const isSelected = context.value === value;
+  return (
+    <div
+      {...rest}
+      ref={ref}
+      role="tabpanel"
+      id={context.getPanelId(value)}
+      aria-labelledby={context.getTriggerId(value)}
+      hidden={!isSelected}
+      aria-hidden={!isSelected}
+      tabIndex={0}
+      className={cx("mosaic-tabs__panel", className)}
+      data-state={isSelected ? "active" : "inactive"}
+    >
+      {children}
+    </div>
+  );
+});
+
+TabsPanel.displayName = "Tabs.Panel";
+
+export interface TabsComponent extends ForwardRefExoticComponent<TabsProps & RefAttributes<HTMLDivElement>> {
+  List: typeof TabsList;
+  Trigger: typeof TabsTrigger;
+  Panel: typeof TabsPanel;
+}
+
+export const Tabs = Object.assign(TabsRoot, {
+  List: TabsList,
+  Trigger: TabsTrigger,
+  Panel: TabsPanel,
+}) as TabsComponent;
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export { ContextMenu } from "./components/ContextMenu";
 export { DataTable } from "./components/DataTable";
 export { DatePicker } from "./components/DatePicker";
 export { Dialog } from "./components/Dialog";
+export { Tabs } from "./components/Tabs";
+export { Accordion } from "./components/Accordion";
 export { Pagination } from "./components/Pagination";
 export { Progress } from "./components/Progress";
 export { RadioGroup, Radio } from "./components/RadioGroup";

--- a/src/theme/baseStyles.ts
+++ b/src/theme/baseStyles.ts
@@ -1213,6 +1213,203 @@ export const baseStyles = `
   color: var(--mosaic-color-text-muted);
 }
 
+.mosaic-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-md);
+}
+
+.mosaic-tabs[data-orientation="vertical"] {
+  flex-direction: row;
+  align-items: stretch;
+  gap: var(--mosaic-spacing-lg);
+}
+
+.mosaic-tabs__list {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mosaic-spacing-xs);
+  border-bottom: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  padding-bottom: var(--mosaic-spacing-xs);
+}
+
+.mosaic-tabs[data-orientation="vertical"] .mosaic-tabs__list {
+  flex-direction: column;
+  align-items: stretch;
+  border-bottom: none;
+  border-right: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  padding-bottom: 0;
+  padding-right: var(--mosaic-spacing-sm);
+}
+
+.mosaic-tabs__trigger {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mosaic-spacing-xs);
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-radius: var(--mosaic-radius-md);
+  color: var(--mosaic-color-text-muted);
+  font: inherit;
+  font-weight: 600;
+  padding: var(--mosaic-spacing-xs) var(--mosaic-spacing-md);
+  cursor: pointer;
+  transition: color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    box-shadow var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-tabs__trigger:hover:not([disabled]),
+.mosaic-tabs__trigger:focus-visible:not([disabled]) {
+  color: var(--mosaic-color-text);
+  background-color: var(--mosaic-color-surface-hover);
+}
+
+.mosaic-tabs__trigger:focus-visible {
+  outline: none;
+  box-shadow: var(--mosaic-focus-ring);
+}
+
+.mosaic-tabs__trigger[data-state="active"] {
+  color: var(--mosaic-color-text);
+}
+
+.mosaic-tabs__trigger[data-disabled="true"],
+.mosaic-tabs__trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.mosaic-tabs__trigger::after {
+  content: "";
+  position: absolute;
+  left: var(--mosaic-spacing-sm);
+  right: var(--mosaic-spacing-sm);
+  bottom: calc(-1 * var(--mosaic-border-width));
+  height: 0.2rem;
+  border-radius: 999px;
+  background-color: var(--mosaic-color-primary);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-tabs__trigger[data-state="active"]::after {
+  transform: scaleX(1);
+}
+
+.mosaic-tabs[data-orientation="vertical"] .mosaic-tabs__trigger::after {
+  top: var(--mosaic-spacing-sm);
+  bottom: var(--mosaic-spacing-sm);
+  left: auto;
+  right: calc(-1 * var(--mosaic-border-width));
+  width: 0.2rem;
+  height: auto;
+  transform: scaleY(0);
+  transform-origin: top;
+}
+
+.mosaic-tabs[data-orientation="vertical"] .mosaic-tabs__trigger[data-state="active"]::after {
+  transform: scaleY(1);
+}
+
+.mosaic-tabs__panel {
+  padding-top: var(--mosaic-spacing-sm);
+  color: var(--mosaic-color-text);
+}
+
+.mosaic-tabs[data-orientation="vertical"] .mosaic-tabs__panel {
+  flex: 1;
+}
+
+.mosaic-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-sm);
+}
+
+.mosaic-accordion__item {
+  border: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  border-radius: var(--mosaic-radius-lg);
+  background-color: var(--mosaic-color-surface);
+  overflow: hidden;
+  transition: border-color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    box-shadow var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-accordion__item[data-state="open"] {
+  border-color: var(--mosaic-color-primary-border, var(--mosaic-color-primary));
+  box-shadow: var(--mosaic-shadow-sm);
+}
+
+.mosaic-accordion__item[data-disabled="true"] {
+  opacity: 0.6;
+}
+
+.mosaic-accordion__trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--mosaic-spacing-sm);
+  padding: var(--mosaic-spacing-md);
+  background: transparent;
+  border: none;
+  font: inherit;
+  font-weight: 600;
+  color: var(--mosaic-color-text);
+  text-align: left;
+  cursor: pointer;
+  transition: color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
+    background-color var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+  position: relative;
+}
+
+.mosaic-accordion__trigger:hover:not([disabled]),
+.mosaic-accordion__trigger:focus-visible:not([disabled]) {
+  background-color: var(--mosaic-color-surface-hover);
+}
+
+.mosaic-accordion__trigger:focus-visible {
+  outline: none;
+  box-shadow: var(--mosaic-focus-ring);
+}
+
+.mosaic-accordion__trigger[data-disabled="true"],
+.mosaic-accordion__trigger:disabled {
+  cursor: not-allowed;
+  background: transparent;
+  box-shadow: none;
+}
+
+.mosaic-accordion__trigger::after {
+  content: "";
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform var(--mosaic-motion-duration) var(--mosaic-motion-ease);
+}
+
+.mosaic-accordion__trigger[data-state="open"]::after {
+  transform: rotate(225deg);
+}
+
+.mosaic-accordion__content {
+  padding: 0 var(--mosaic-spacing-md) var(--mosaic-spacing-md);
+  border-top: var(--mosaic-border-width) solid var(--mosaic-color-border);
+  color: var(--mosaic-color-text);
+}
+
+.mosaic-accordion__content > *:first-child {
+  margin-top: var(--mosaic-spacing-sm);
+}
+
 .mosaic-context-menu {
   position: fixed;
   z-index: 950;


### PR DESCRIPTION
## Summary
- add accessible Tabs primitive with keyboard roving focus, manual/automatic activation, and panel wiring
- introduce Accordion with single/multiple expansion modes, arrow-key navigation, and disabled handling
- style both primitives, document usage in the README, export from the package entrypoint, and surface interactive examples in the kitchen-sink demo

## Testing
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0ce465f34832e82850dde6afa4930