### PR TITLE
Add alert banner and loading primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Pass an array to `defaultValue`/`value` when `type="multiple"`, and set `collaps
 
 ### Components
 
+- `Alert` – Tone-aware banners with dismissible info, success, warning, and error states.
 - `Avatar` – Adaptive initials and imagery with sizing and fallback states.
 - `Badge` – Tone-aware indicators with solid, soft, and outline variants.
 - `Button` – Solid, soft, outline, ghost, and loading states with tone tokens.
@@ -184,6 +185,8 @@ Pass an array to `defaultValue`/`value` when `type="multiple"`, and set `collaps
 - `Slider` – Accessible range input with accent-aware focus and error states.
 - `Pagination` – Paginated navigation with ellipsis handling.
 - `Progress` – Determinate and indeterminate indicators with optional labels.
+- `Skeleton` – Animated placeholders that pause automatically when reduced motion is enabled.
+- `Spinner` – Inline loading indicator that shares motion tokens with `Progress`.
 - `Textarea` – Multi-line input with size controls and shared token styling.
 - `Stack` – Flexbox layout utility for column/row alignment and spacing.
 - `Switch` – Accessible toggle with descriptive text support.

--- a/docs/App.tsx
+++ b/docs/App.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import {
   Accordion,
+  Alert,
   Avatar,
   Badge,
   Button,
@@ -17,8 +18,10 @@ import {
   RadioGroup,
   Pagination,
   Progress,
+  Skeleton,
   Sheet,
   Select,
+  Spinner,
   Slider,
   Stack,
   Switch,
@@ -151,6 +154,8 @@ const App = () => {
   const [notes, setNotes] = useState("");
   const [progress, setProgress] = useState(45);
   const [volume, setVolume] = useState(60);
+  const [showInfoAlert, setShowInfoAlert] = useState(true);
+  const [showSkeleton, setShowSkeleton] = useState(true);
   const themePanelRef = useRef<HTMLDivElement | null>(null);
   const { toast } = useToast();
   const { togglePalette } = useCommandPalette();
@@ -354,15 +359,101 @@ const App = () => {
         <section>
           <Text variant="title">Progress & feedback</Text>
           <Card className="app-panel" shadow="md">
-            <Stack gap="sm">
-              <Progress label="Invite campaign" value={progress} showValue />
-              <Stack direction="row" gap="sm">
-                <Button tone="neutral" variant="outline" onClick={() => setProgress((value) => Math.max(0, value - 10))}>
-                  Slow down
+            <Stack gap="lg">
+              <Stack gap="sm">
+                <Progress label="Invite campaign" value={progress} showValue />
+                <Stack direction="row" gap="sm">
+                  <Button tone="neutral" variant="outline" onClick={() => setProgress((value) => Math.max(0, value - 10))}>
+                    Slow down
+                  </Button>
+                  <Button tone="primary" onClick={() => setProgress((value) => Math.min(100, value + 10))}>
+                    Speed up
+                  </Button>
+                </Stack>
+              </Stack>
+
+              <Stack gap="sm">
+                <Text variant="label">Announcements</Text>
+                {showInfoAlert ? (
+                  <Alert
+                    tone="info"
+                    heading="Workspace research hub"
+                    description="Share curated studies and insights with stakeholders."
+                    icon="ℹ️"
+                    actions={
+                      <Button size="sm" variant="ghost" tone="primary">
+                        Review plan
+                      </Button>
+                    }
+                    onDismiss={() => setShowInfoAlert(false)}
+                  />
+                ) : (
+                  <Button size="sm" variant="ghost" tone="neutral" onClick={() => setShowInfoAlert(true)}>
+                    Restore informational alert
+                  </Button>
+                )}
+                <Alert
+                  tone="success"
+                  heading="Launch checklist complete"
+                  description="All validation tasks have passed and the release is ready."
+                  icon="✔️"
+                />
+                <Alert
+                  tone="warning"
+                  heading="Sandbox tokens expiring soon"
+                  description="Rotate credentials within the next 24 hours to avoid downtime."
+                  icon="⚠️"
+                  actions={
+                    <Button size="sm" variant="outline" tone="warning">
+                      Rotate keys
+                    </Button>
+                  }
+                />
+                <Alert
+                  tone="error"
+                  heading="Billing sync failed"
+                  description="Retry the connection or update the API key to restore exports."
+                  icon="⛔️"
+                />
+              </Stack>
+
+              <Stack gap="sm">
+                <Text variant="label">Loading states</Text>
+                <Stack direction="row" gap="sm" align="center">
+                  {showSkeleton ? (
+                    <Spinner size="sm" tone="primary" label="Syncing workspace content" />
+                  ) : (
+                    <Badge tone="success" variant="soft">
+                      Synced
+                    </Badge>
+                  )}
+                  <Text variant="body">
+                    {showSkeleton ? "Syncing workspace content…" : "Workspace content is up to date."}
+                  </Text>
+                </Stack>
+                <Button size="sm" variant="ghost" tone="neutral" onClick={() => setShowSkeleton((value) => !value)}>
+                  {showSkeleton ? "Show loaded preview" : "Reset placeholders"}
                 </Button>
-                <Button tone="primary" onClick={() => setProgress((value) => Math.min(100, value + 10))}>
-                  Speed up
-                </Button>
+                {showSkeleton ? (
+                  <Stack gap="sm">
+                    <Stack direction="row" gap="sm" align="center">
+                      <Skeleton variant="circle" style={{ width: "2.5rem", height: "2.5rem" }} />
+                      <Stack gap="xs" style={{ flex: 1 }}>
+                        <Skeleton variant="text" style={{ width: "60%" }} />
+                        <Skeleton variant="text" style={{ width: "40%" }} />
+                      </Stack>
+                    </Stack>
+                    <Skeleton style={{ height: "6rem" }} />
+                  </Stack>
+                ) : (
+                  <Stack gap="xs">
+                    <Text variant="body">Team insights and charts are ready to share.</Text>
+                    <Text variant="caption">Reset placeholders to preview the skeleton shimmer again.</Text>
+                  </Stack>
+                )}
+                <Text variant="caption">
+                  Toggle reduced motion in the theme panel to pause the spinner and shimmer automatically.
+                </Text>
               </Stack>
             </Stack>
           </Card>

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,128 @@
+import {
+  forwardRef,
+  type AriaAttributes,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+import { getCssVar } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+export type AlertTone = "info" | "success" | "warning" | "error";
+
+export interface AlertProps extends HTMLAttributes<HTMLDivElement> {
+  tone?: AlertTone;
+  heading?: ReactNode;
+  description?: ReactNode;
+  icon?: ReactNode;
+  actions?: ReactNode;
+  onDismiss?: () => void;
+  dismissLabel?: string;
+}
+
+const toneStyles: Record<AlertTone, Record<string, string>> = {
+  info: {
+    "--mosaic-alert-bg": getCssVar("color-primary-soft"),
+    "--mosaic-alert-border": getCssVar("color-primary-border"),
+    "--mosaic-alert-accent": getCssVar("color-primary"),
+    "--mosaic-alert-title": getCssVar("color-primary"),
+    "--mosaic-alert-icon": getCssVar("color-primary"),
+  },
+  success: {
+    "--mosaic-alert-bg": getCssVar("color-success-soft"),
+    "--mosaic-alert-border": getCssVar("color-success-border"),
+    "--mosaic-alert-accent": getCssVar("color-success"),
+    "--mosaic-alert-title": getCssVar("color-success"),
+    "--mosaic-alert-icon": getCssVar("color-success"),
+  },
+  warning: {
+    "--mosaic-alert-bg": getCssVar("color-warning-soft"),
+    "--mosaic-alert-border": getCssVar("color-warning-border"),
+    "--mosaic-alert-accent": getCssVar("color-warning"),
+    "--mosaic-alert-title": getCssVar("color-warning"),
+    "--mosaic-alert-icon": getCssVar("color-warning"),
+  },
+  error: {
+    "--mosaic-alert-bg": getCssVar("color-danger-soft"),
+    "--mosaic-alert-border": getCssVar("color-danger-border"),
+    "--mosaic-alert-accent": getCssVar("color-danger"),
+    "--mosaic-alert-title": getCssVar("color-danger"),
+    "--mosaic-alert-icon": getCssVar("color-danger"),
+  },
+};
+
+const defaultRoles: Record<AlertTone, "alert" | "status"> = {
+  info: "status",
+  success: "status",
+  warning: "alert",
+  error: "alert",
+};
+
+export const Alert = forwardRef<HTMLDivElement, AlertProps>((props, ref) => {
+  const {
+    tone = "info",
+    heading,
+    description,
+    icon,
+    actions,
+    onDismiss,
+    dismissLabel = "Dismiss alert",
+    className,
+    style,
+    children,
+    role: roleProp,
+    ...rest
+  } = props;
+
+  const { ["aria-live"]: ariaLiveProp, ...restProps } = rest as typeof rest & {
+    ["aria-live"]?: AriaAttributes["aria-live"];
+  };
+
+  const role = roleProp ?? defaultRoles[tone];
+  const ariaLive = ariaLiveProp ?? (role === "alert" ? "assertive" : "polite");
+
+  const styles: CSSProperties = {
+    ...toneStyles[tone],
+    ...(style as CSSProperties | undefined),
+  };
+
+  return (
+    <div
+      ref={ref}
+      className={cx("mosaic-alert", className)}
+      data-tone={tone}
+      role={role}
+      aria-live={ariaLive}
+      style={styles}
+      {...restProps}
+    >
+      <div className="mosaic-alert__body">
+        {icon ? (
+          <span className="mosaic-alert__icon" aria-hidden="true">
+            {icon}
+          </span>
+        ) : null}
+        <div className="mosaic-alert__content">
+          {heading ? <div className="mosaic-alert__title">{heading}</div> : null}
+          {description ? (
+            <div className="mosaic-alert__description">{description}</div>
+          ) : null}
+          {children}
+          {actions ? <div className="mosaic-alert__actions">{actions}</div> : null}
+        </div>
+      </div>
+      {onDismiss ? (
+        <button
+          type="button"
+          className="mosaic-alert__dismiss"
+          onClick={onDismiss}
+          aria-label={dismissLabel}
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      ) : null}
+    </div>
+  );
+});
+
+Alert.displayName = "Alert";

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,39 @@
+import { forwardRef, type CSSProperties, type HTMLAttributes } from "react";
+import { getCssVar } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+
+export type SkeletonVariant = "rect" | "text" | "circle";
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: SkeletonVariant;
+  animate?: boolean;
+}
+
+export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>((props, ref) => {
+  const { variant = "rect", animate = true, className, style, ...rest } = props;
+
+  const skeletonVars: Record<string, string> = {
+    "--mosaic-skeleton-base": getCssVar("color-surface-hover"),
+    "--mosaic-skeleton-highlight": getCssVar("color-surface"),
+  };
+
+  const styles: CSSProperties = {
+    ...skeletonVars,
+    ...(style as CSSProperties | undefined),
+  };
+
+  return (
+    <div
+      ref={ref}
+      className={cx("mosaic-skeleton", className)}
+      data-variant={variant}
+      data-animate={animate ? undefined : "false"}
+      role="presentation"
+      aria-hidden="true"
+      style={styles}
+      {...rest}
+    />
+  );
+});
+
+Skeleton.displayName = "Skeleton";

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,81 @@
+import {
+  forwardRef,
+  type AriaAttributes,
+  type CSSProperties,
+  type HTMLAttributes,
+} from "react";
+import { getCssVar } from "../theme/ThemeProvider";
+import { cx } from "../utils/cx";
+import { VisuallyHidden } from "./VisuallyHidden";
+
+type SpinnerTone = "neutral" | "primary" | "success" | "warning" | "danger";
+type SpinnerSize = "sm" | "md" | "lg";
+
+export interface SpinnerProps extends Omit<HTMLAttributes<HTMLSpanElement>, "children"> {
+  tone?: SpinnerTone;
+  size?: SpinnerSize;
+  label?: string;
+}
+
+const toneStyles: Record<SpinnerTone, Record<string, string>> = {
+  neutral: {
+    "--mosaic-spinner-color": getCssVar("color-neutral"),
+    "--mosaic-spinner-track": getCssVar("color-neutral-border"),
+  },
+  primary: {
+    "--mosaic-spinner-color": getCssVar("color-primary"),
+    "--mosaic-spinner-track": getCssVar("color-primary-border"),
+  },
+  success: {
+    "--mosaic-spinner-color": getCssVar("color-success"),
+    "--mosaic-spinner-track": getCssVar("color-success-border"),
+  },
+  warning: {
+    "--mosaic-spinner-color": getCssVar("color-warning"),
+    "--mosaic-spinner-track": getCssVar("color-warning-border"),
+  },
+  danger: {
+    "--mosaic-spinner-color": getCssVar("color-danger"),
+    "--mosaic-spinner-track": getCssVar("color-danger-border"),
+  },
+};
+
+const sizeMap: Record<SpinnerSize, string> = {
+  sm: "1rem",
+  md: "1.5rem",
+  lg: "2rem",
+};
+
+export const Spinner = forwardRef<HTMLSpanElement, SpinnerProps>((props, ref) => {
+  const { tone = "primary", size = "md", label = "Loading", className, style, ...rest } = props;
+
+  const { ["aria-live"]: ariaLiveProp, ...restProps } = rest as typeof rest & {
+    ["aria-live"]?: AriaAttributes["aria-live"];
+  };
+
+  const sizeVars: Record<string, string> = {
+    "--mosaic-spinner-size": sizeMap[size],
+  };
+
+  const styles: CSSProperties = {
+    ...toneStyles[tone],
+    ...sizeVars,
+    ...(style as CSSProperties | undefined),
+  };
+
+  return (
+    <span
+      ref={ref}
+      className={cx("mosaic-spinner", className)}
+      role="status"
+      aria-live={ariaLiveProp ?? "polite"}
+      style={styles}
+      {...restProps}
+    >
+      <span className="mosaic-spinner__circle" aria-hidden="true" />
+      <VisuallyHidden>{label}</VisuallyHidden>
+    </span>
+  );
+});
+
+Spinner.displayName = "Spinner";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { Alert } from "./components/Alert";
 export { Button } from "./components/Button";
 export { Card } from "./components/Card";
 export { Field } from "./components/Field";
@@ -20,8 +21,10 @@ export { Accordion } from "./components/Accordion";
 export { Pagination } from "./components/Pagination";
 export { Progress } from "./components/Progress";
 export { RadioGroup, Radio } from "./components/RadioGroup";
+export { Skeleton } from "./components/Skeleton";
 export { Sheet } from "./components/Sheet";
 export { Select } from "./components/Select";
+export { Spinner } from "./components/Spinner";
 export { Switch } from "./components/Switch";
 export { Slider } from "./components/Slider";
 export { ToastProvider, useToast } from "./components/Toast";

--- a/src/theme/baseStyles.ts
+++ b/src/theme/baseStyles.ts
@@ -158,6 +158,94 @@ export const baseStyles = `
   --mosaic-card-border: var(--mosaic-color-primary-border);
 }
 
+.mosaic-alert {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--mosaic-spacing-md);
+  padding-block: var(--mosaic-spacing-sm);
+  padding-inline: var(--mosaic-spacing-md);
+  padding-inline-start: calc(var(--mosaic-spacing-md) + 0.5rem);
+  background-color: var(--mosaic-alert-bg, var(--mosaic-color-surface));
+  border: var(--mosaic-border-width) solid var(--mosaic-alert-border, var(--mosaic-color-border));
+  border-radius: var(--mosaic-radius-lg);
+  color: var(--mosaic-alert-fg, var(--mosaic-color-text));
+}
+
+.mosaic-alert::before {
+  content: "";
+  position: absolute;
+  inset-block: var(--mosaic-spacing-sm);
+  inset-inline-start: var(--mosaic-spacing-sm);
+  width: 0.3rem;
+  border-radius: 999px;
+  background-color: var(--mosaic-alert-accent, var(--mosaic-color-primary));
+}
+
+.mosaic-alert__body {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--mosaic-spacing-md);
+  flex: 1;
+  min-width: 0;
+}
+
+.mosaic-alert__icon {
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--mosaic-alert-icon, var(--mosaic-alert-accent, var(--mosaic-color-primary)));
+  margin-top: 0.125rem;
+}
+
+.mosaic-alert__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mosaic-spacing-xs);
+  flex: 1;
+  min-width: 0;
+}
+
+.mosaic-alert__title {
+  font-weight: 600;
+  color: var(--mosaic-alert-title, var(--mosaic-color-text));
+  font-size: var(--mosaic-text-size-md);
+  line-height: var(--mosaic-line-height-tight);
+}
+
+.mosaic-alert__description {
+  color: var(--mosaic-alert-description, var(--mosaic-color-text-muted));
+  font-size: var(--mosaic-text-size-sm);
+  line-height: var(--mosaic-line-height-normal);
+}
+
+.mosaic-alert__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mosaic-spacing-xs);
+  margin-top: var(--mosaic-spacing-xs);
+}
+
+.mosaic-alert__dismiss {
+  border: none;
+  background: transparent;
+  color: var(--mosaic-alert-dismiss, var(--mosaic-color-text-muted));
+  border-radius: var(--mosaic-radius-sm);
+  padding: var(--mosaic-spacing-xs);
+  cursor: pointer;
+  line-height: 1;
+  align-self: flex-start;
+}
+
+.mosaic-alert__dismiss:hover,
+.mosaic-alert__dismiss:focus-visible {
+  color: var(--mosaic-alert-accent, var(--mosaic-color-primary));
+}
+
+.mosaic-alert__dismiss:focus-visible {
+  outline: none;
+  box-shadow: var(--mosaic-focus-ring);
+}
+
 .mosaic-text {
   margin: 0;
   color: var(--mosaic-text-color, inherit);
@@ -1037,6 +1125,78 @@ export const baseStyles = `
   }
   50% {
     transform: translateX(20%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.mosaic-spinner {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.mosaic-spinner__circle {
+  width: var(--mosaic-spinner-size, 1.5rem);
+  height: var(--mosaic-spinner-size, 1.5rem);
+  border-radius: 50%;
+  border: 3px solid var(--mosaic-spinner-track, var(--mosaic-color-border));
+  border-top-color: var(--mosaic-spinner-color, var(--mosaic-color-primary));
+  border-right-color: var(--mosaic-spinner-color, var(--mosaic-color-primary));
+  box-sizing: border-box;
+  animation: mosaic-spin calc(var(--mosaic-motion-duration) * 6) var(--mosaic-motion-ease) infinite;
+}
+
+[data-mosaic-reduced-motion="true"] .mosaic-spinner__circle {
+  animation: none;
+}
+
+.mosaic-skeleton {
+  position: relative;
+  overflow: hidden;
+  display: block;
+  background-color: var(--mosaic-skeleton-base, var(--mosaic-color-surface-hover));
+  border-radius: var(--mosaic-skeleton-radius, var(--mosaic-radius-md));
+  min-height: 0.5rem;
+}
+
+.mosaic-skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--mosaic-skeleton-highlight, var(--mosaic-color-surface)) 50%,
+    transparent 100%
+  );
+  transform: translateX(-100%);
+  animation: mosaic-skeleton-shimmer calc(var(--mosaic-motion-duration) * 12) var(--mosaic-motion-ease) infinite;
+}
+
+.mosaic-skeleton[data-variant="text"] {
+  border-radius: var(--mosaic-radius-sm);
+  height: 1em;
+  width: 100%;
+}
+
+.mosaic-skeleton[data-variant="circle"] {
+  border-radius: 999px;
+}
+
+.mosaic-skeleton[data-animate="false"]::after {
+  display: none;
+}
+
+[data-mosaic-reduced-motion="true"] .mosaic-skeleton::after {
+  animation: none;
+}
+
+@keyframes mosaic-skeleton-shimmer {
+  0% {
+    transform: translateX(-100%);
   }
   100% {
     transform: translateX(100%);


### PR DESCRIPTION
## Summary
- add a tone-aware Alert component with semantic roles and dismiss controls
- introduce Spinner and Skeleton loading primitives that share Mosaic motion tokens
- export the new primitives, document them in the README, and surface playground demos for tone and reduced-motion behavior

## Testing
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0d2f00ef8832e965a9a5310e1ef6a