### PR TITLE
Refresh theme styling to match shadcn aesthetic

### DIFF
--- a/src/theme/baseStyles.ts
+++ b/src/theme/baseStyles.ts
@@ -1,6 +1,6 @@
 export const baseStyles = `
 :root {
-  --mosaic-focus-ring: 0 0 0 1.5px var(--mosaic-color-surface), 0 0 0 4px var(--mosaic-color-ring);
+  --mosaic-focus-ring: 0 0 0 2px var(--mosaic-color-background), 0 0 0 4px var(--mosaic-color-ring);
 }
 
 .mosaic-button {
@@ -9,14 +9,14 @@ export const baseStyles = `
   --mosaic-button-shadow-active: var(--mosaic-button-shadow);
   appearance: none;
   border: var(--mosaic-border-width) solid var(--mosaic-button-border, transparent);
-  border-radius: var(--mosaic-radius-md);
+  border-radius: var(--mosaic-radius-sm);
   background-color: var(--mosaic-button-bg, transparent);
   color: var(--mosaic-button-fg, var(--mosaic-color-text));
   font-family: var(--mosaic-font-family-base);
   font-weight: 500;
   font-size: var(--mosaic-button-font-size, var(--mosaic-text-size-md));
   line-height: var(--mosaic-line-height-tight);
-  letter-spacing: -0.015em;
+  letter-spacing: 0;
   padding-block: var(--mosaic-button-padding-y, var(--mosaic-spacing-sm));
   padding-inline: var(--mosaic-button-padding-x, var(--mosaic-spacing-md));
   display: inline-flex;
@@ -31,7 +31,7 @@ export const baseStyles = `
     border-color var(--mosaic-motion-duration) var(--mosaic-motion-ease),
     box-shadow var(--mosaic-motion-duration) var(--mosaic-motion-ease),
     transform var(--mosaic-motion-duration) var(--mosaic-motion-ease);
-  min-height: calc(2.75rem + var(--mosaic-button-size-adjust, 0));
+  min-height: calc(2.5rem + var(--mosaic-button-size-adjust, 0));
   box-shadow: var(--mosaic-button-shadow);
 }
 
@@ -59,7 +59,6 @@ export const baseStyles = `
 
 .mosaic-button[data-variant="solid"]:active:not(:disabled) {
   background-color: var(--mosaic-button-bg-active, var(--mosaic-button-bg));
-  transform: translateY(1px);
 }
 
 .mosaic-button[data-variant="soft"] {
@@ -211,7 +210,6 @@ export const baseStyles = `
 
 .mosaic-card[data-hoverable="true"]:hover {
   box-shadow: var(--mosaic-card-shadow-hover, var(--mosaic-shadow-md));
-  transform: translateY(-2px);
   background-color: var(--mosaic-card-bg-hover, var(--mosaic-card-bg, var(--mosaic-color-surface-hover)));
   border-color: var(--mosaic-card-border-hover, var(--mosaic-card-border, var(--mosaic-color-border)));
 }
@@ -229,13 +227,13 @@ export const baseStyles = `
   position: relative;
   display: flex;
   align-items: flex-start;
-  gap: var(--mosaic-spacing-md);
-  padding-block: var(--mosaic-spacing-sm);
+  gap: var(--mosaic-spacing-sm);
+  padding-block: calc(var(--mosaic-spacing-sm) + 0.125rem);
   padding-inline: var(--mosaic-spacing-md);
-  padding-inline-start: calc(var(--mosaic-spacing-md) + 0.5rem);
+  padding-inline-start: calc(var(--mosaic-spacing-md) + 0.25rem);
   background-color: var(--mosaic-alert-bg, var(--mosaic-color-surface));
   border: var(--mosaic-border-width) solid var(--mosaic-alert-border, var(--mosaic-color-border));
-  border-radius: var(--mosaic-radius-lg);
+  border-radius: var(--mosaic-radius-md);
   color: var(--mosaic-alert-fg, var(--mosaic-color-text));
   box-shadow: var(--mosaic-alert-shadow, var(--mosaic-shadow-sm));
 }
@@ -245,7 +243,7 @@ export const baseStyles = `
   position: absolute;
   inset-block: var(--mosaic-spacing-sm);
   inset-inline-start: var(--mosaic-spacing-sm);
-  width: 0.3rem;
+  width: 0.25rem;
   border-radius: 999px;
   background-color: var(--mosaic-alert-accent, var(--mosaic-color-primary));
 }
@@ -382,9 +380,9 @@ export const baseStyles = `
 .mosaic-input {
   width: 100%;
   font: inherit;
-  padding-block: var(--mosaic-input-padding-y, var(--mosaic-spacing-sm));
-  padding-inline: var(--mosaic-input-padding-x, var(--mosaic-spacing-md));
-  border-radius: var(--mosaic-radius-md);
+  padding-block: var(--mosaic-input-padding-y, calc(var(--mosaic-spacing-sm) - 0.25rem));
+  padding-inline: var(--mosaic-input-padding-x, calc(var(--mosaic-spacing-md) - 0.375rem));
+  border-radius: var(--mosaic-radius-sm);
   border: var(--mosaic-border-width) solid var(--mosaic-color-border);
   background-color: var(--mosaic-color-surface);
   color: var(--mosaic-color-text);
@@ -422,9 +420,9 @@ export const baseStyles = `
   width: 100%;
   min-height: 6rem;
   font: inherit;
-  padding-block: var(--mosaic-textarea-padding-y, var(--mosaic-spacing-sm));
-  padding-inline: var(--mosaic-textarea-padding-x, var(--mosaic-spacing-md));
-  border-radius: var(--mosaic-radius-md);
+  padding-block: var(--mosaic-textarea-padding-y, calc(var(--mosaic-spacing-sm) - 0.25rem));
+  padding-inline: var(--mosaic-textarea-padding-x, calc(var(--mosaic-spacing-md) - 0.375rem));
+  border-radius: var(--mosaic-radius-sm);
   border: var(--mosaic-border-width) solid var(--mosaic-color-border);
   background-color: var(--mosaic-color-surface);
   color: var(--mosaic-color-text);

--- a/src/theme/color.ts
+++ b/src/theme/color.ts
@@ -121,26 +121,26 @@ const colorVisionSemantics: Record<ColorVisionMode, Partial<typeof semanticDefau
 };
 
 const baseLight = {
-  background: "#f4f4f5",
+  background: "#f8fafc",
   surface: "#ffffff",
-  surfaceHover: "#f7f7f8",
-  surfaceActive: "#eeeeef",
-  border: "#e4e4e7",
+  surfaceHover: "#f4f4f5",
+  surfaceActive: "#e4e4e7",
+  border: "#e2e8f0",
 };
 
 const baseDark = {
-  background: "#09090b",
-  surface: "#111114",
-  surfaceHover: "#18181c",
-  surfaceActive: "#1f1f24",
-  border: "#27272a",
+  background: "#020817",
+  surface: "#0f172a",
+  surfaceHover: "#1e293b",
+  surfaceActive: "#334155",
+  border: "#1e293b",
 };
 
 const lighten = (color: string, amount: number) => mix(color, "#ffffff", amount);
 const darken = (color: string, amount: number) => mix(color, "#000000", amount);
 
 const neutralFromAppearance = (appearance: Appearance) =>
-  appearance === "light" ? "#18181b" : "#d4d4d8";
+  appearance === "light" ? "#1f2937" : "#cbd5f5";
 
 const highContrastBackground = (appearance: Appearance) =>
   appearance === "light" ? "#ffffff" : "#000000";
@@ -207,11 +207,11 @@ const buildTokens = (options: ThemeOptions): ThemeTokens => {
   const textBase = highContrast
     ? highContrastText(appearance)
     : appearance === "light"
-      ? "#111114"
-      : "#f5f5f6";
-  const textMuted = appearance === "light" ? "#3f3f46" : "#a1a1aa";
-  const textSubtle = appearance === "light" ? "#71717a" : "#8f90a6";
-  const inverted = appearance === "light" ? "#ffffff" : "#09090b";
+      ? "#0f172a"
+      : "#e2e8f0";
+  const textMuted = appearance === "light" ? "#475569" : "#94a3b8";
+  const textSubtle = appearance === "light" ? "#64748b" : "#cbd5f5";
+  const inverted = appearance === "light" ? "#020817" : "#f8fafc";
 
   const neutralSoftBase = appearance === "light" ? lighten(neutral, 0.9) : darken(neutral, 0.55);
 
@@ -272,18 +272,18 @@ const buildTokens = (options: ThemeOptions): ThemeTokens => {
     "line-height-tight": "1.2",
     "line-height-normal": "1.5",
     "line-height-relaxed": "1.7",
-    "radius-sm": "0.75rem",
-    "radius-md": "1rem",
-    "radius-lg": "1.5rem",
+    "radius-sm": "0.5rem",
+    "radius-md": "0.75rem",
+    "radius-lg": "1rem",
     "shadow-sm": appearance === "light"
-      ? "0 1px 2px rgba(15, 23, 42, 0.12), 0 1px 0 rgba(15, 23, 42, 0.06)"
-      : "0 1px 2px rgba(2, 6, 23, 0.7), 0 1px 0 rgba(148, 163, 184, 0.12)",
+      ? "0 1px 2px 0 rgba(15, 23, 42, 0.08)"
+      : "0 1px 2px 0 rgba(2, 6, 23, 0.75)",
     "shadow-md": appearance === "light"
-      ? "0 12px 32px -18px rgba(15, 23, 42, 0.22), 0 6px 18px -12px rgba(15, 23, 42, 0.18), 0 0 0 1px rgba(15, 23, 42, 0.06)"
-      : "0 22px 48px -24px rgba(2, 6, 23, 0.74), 0 10px 32px -18px rgba(15, 23, 42, 0.48), 0 0 0 1px rgba(148, 163, 184, 0.14)",
+      ? "0 4px 6px -1px rgba(15, 23, 42, 0.12), 0 2px 4px -1px rgba(15, 23, 42, 0.08)"
+      : "0 8px 12px -2px rgba(2, 6, 23, 0.78), 0 4px 6px -2px rgba(15, 23, 42, 0.5)",
     "shadow-lg": appearance === "light"
-      ? "0 28px 64px -34px rgba(15, 23, 42, 0.24), 0 14px 36px -24px rgba(15, 23, 42, 0.2), 0 0 0 1px rgba(15, 23, 42, 0.05)"
-      : "0 36px 84px -36px rgba(2, 6, 23, 0.78), 0 18px 54px -28px rgba(15, 23, 42, 0.52), 0 0 0 1px rgba(148, 163, 184, 0.16)",
+      ? "0 16px 32px -12px rgba(15, 23, 42, 0.16), 0 8px 16px -8px rgba(15, 23, 42, 0.08)"
+      : "0 24px 44px -18px rgba(2, 6, 23, 0.82), 0 12px 24px -12px rgba(15, 23, 42, 0.55)",
     "border-width": highContrast ? "2px" : "1px",
     "motion-duration": reducedMotion ? "0ms" : "180ms",
     "motion-ease": reducedMotion ? "linear" : "cubic-bezier(0.16, 1, 0.3, 1)",


### PR DESCRIPTION
## Summary
- retune the base theme tokens to match shadcn-inspired backgrounds, typography colors, radii, and shadows
- tighten button, card, alert, and form control styles for a lower-radius, higher-contrast presentation

## Testing
- bun run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d0e54197a8832e84f5ee5fd45af807